### PR TITLE
JAM-6: Add auto-generated API documentation with typedoc

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
-npm run docs
-git add docs/
+if git diff --cached --name-only | grep -qE '^(src/|guides/|typedoc\.json)'; then
+  npm run docs
+  git add docs/
+fi
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+npm run docs
+git add docs/
 npx lint-staged

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+**jira-action-man**
+
+***
+
 # Jira Action Man
 
 A GitHub Action that extracts Jira issue keys from GitHub events and posts posts PR comments to Jira.

--- a/docs/documents/Configuration.md
+++ b/docs/documents/Configuration.md
@@ -1,0 +1,64 @@
+[**jira-action-man**](../README.md)
+
+***
+
+[jira-action-man](../modules.md) / Configuration
+
+# Configuration
+
+## Action Inputs
+
+### Key Extraction
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `projects` | `""` (match all) | Comma-separated Jira project prefixes to match (e.g. `"PROJ,TEAM"`) |
+| `from` | `"branch,title,commits"` | Comma-separated sources to check: `branch`, `title`, `commits`, `body` |
+| `fail_on_missing` | `"false"` | Fail the action if no Jira keys are found |
+| `blocklist` | `""` (use defaults) | Comma-separated prefixes to ignore. Set to `"none"` to disable |
+| `issue_pattern` | built-in regex | Custom regex pattern for matching issue keys |
+
+### Jira Comment Posting
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `post_to_jira` | `"false"` | Post PR description as a comment on linked Jira tickets |
+| `jira_base_url` | `""` | Jira instance base URL (e.g. `https://yourorg.atlassian.net`) |
+| `jira_email` | `""` | Jira account email for API authentication |
+| `jira_api_token` | `""` | Jira API token for authentication |
+| `jira_comment_mode` | `"update"` | Comment behavior: `update`, `new`, or `minimal` |
+| `jira_fail_on_error` | `"false"` | Fail the action if posting to Jira fails |
+| `github_token` | `""` | GitHub token for modifying PRs |
+
+## Comment Modes
+
+The `jira_comment_mode` input controls how comments are posted to Jira tickets:
+
+- **`update`** — Searches for an existing comment containing the PR URL. If found, updates it in place. If not, creates a new comment. This is the default and avoids duplicate comments on re-runs.
+- **`new`** — Always creates a new comment. Use this if you want a comment trail showing each push.
+- **`minimal`** — Posts a single-line comment with just the PR link instead of the full description.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `keys` | JSON array of unique sorted Jira issue keys (e.g. `["PROJ-1","PROJ-23"]`) |
+| `key` | First Jira issue key found (convenience for single-ticket workflows) |
+| `found` | `"true"` if any keys were found, `"false"` otherwise |
+
+## Example Workflow
+
+```yaml
+- uses: procyon-creative/jira-action-man@v1
+  id: jira
+  with:
+    projects: "PROJ,TEAM"
+    from: "branch,title,commits,body"
+    post_to_jira: "true"
+    jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+    jira_email: ${{ secrets.JIRA_EMAIL }}
+    jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+
+- run: echo "Found keys: ${{ steps.jira.outputs.keys }}"
+```

--- a/docs/extract/README.md
+++ b/docs/extract/README.md
@@ -1,0 +1,18 @@
+[**jira-action-man**](../README.md)
+
+***
+
+[jira-action-man](../modules.md) / extract
+
+# extract
+
+## Variables
+
+- [DEFAULT\_BLOCKLIST](variables/DEFAULT_BLOCKLIST.md)
+- [DEFAULT\_ISSUE\_PATTERN](variables/DEFAULT_ISSUE_PATTERN.md)
+
+## Functions
+
+- [extractKeys](functions/extractKeys.md)
+- [extractKeysFromTexts](functions/extractKeysFromTexts.md)
+- [mergeAndSort](functions/mergeAndSort.md)

--- a/docs/extract/functions/extractKeys.md
+++ b/docs/extract/functions/extractKeys.md
@@ -1,0 +1,33 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [extract](../README.md) / extractKeys
+
+# Function: extractKeys()
+
+> **extractKeys**(`text`, `projects`, `blocklist`, `pattern`): `string`[]
+
+Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L34)
+
+## Parameters
+
+### text
+
+`string`
+
+### projects
+
+`string`[]
+
+### blocklist
+
+`string`[]
+
+### pattern
+
+`RegExp`
+
+## Returns
+
+`string`[]

--- a/docs/extract/functions/extractKeysFromTexts.md
+++ b/docs/extract/functions/extractKeysFromTexts.md
@@ -1,0 +1,33 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [extract](../README.md) / extractKeysFromTexts
+
+# Function: extractKeysFromTexts()
+
+> **extractKeysFromTexts**(`texts`, `projects`, `blocklist`, `pattern`): `string`[]
+
+Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L51)
+
+## Parameters
+
+### texts
+
+`string`[]
+
+### projects
+
+`string`[]
+
+### blocklist
+
+`string`[]
+
+### pattern
+
+`RegExp`
+
+## Returns
+
+`string`[]

--- a/docs/extract/functions/mergeAndSort.md
+++ b/docs/extract/functions/mergeAndSort.md
@@ -1,0 +1,21 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [extract](../README.md) / mergeAndSort
+
+# Function: mergeAndSort()
+
+> **mergeAndSort**(`keys`): `string`[]
+
+Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L63)
+
+## Parameters
+
+### keys
+
+`string`[]
+
+## Returns
+
+`string`[]

--- a/docs/extract/variables/DEFAULT_BLOCKLIST.md
+++ b/docs/extract/variables/DEFAULT_BLOCKLIST.md
@@ -1,0 +1,11 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [extract](../README.md) / DEFAULT\_BLOCKLIST
+
+# Variable: DEFAULT\_BLOCKLIST
+
+> `const` **DEFAULT\_BLOCKLIST**: `string`[]
+
+Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L4)

--- a/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
+++ b/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
@@ -1,0 +1,11 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [extract](../README.md) / DEFAULT\_ISSUE\_PATTERN
+
+# Variable: DEFAULT\_ISSUE\_PATTERN
+
+> `const` **DEFAULT\_ISSUE\_PATTERN**: `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"` = `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"`
+
+Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L1)

--- a/docs/jira/README.md
+++ b/docs/jira/README.md
@@ -1,0 +1,11 @@
+[**jira-action-man**](../README.md)
+
+***
+
+[jira-action-man](../modules.md) / jira
+
+# jira
+
+## Functions
+
+- [postToJira](functions/postToJira.md)

--- a/docs/jira/functions/postToJira.md
+++ b/docs/jira/functions/postToJira.md
@@ -1,0 +1,41 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / postToJira
+
+# Function: postToJira()
+
+> **postToJira**(`keys`, `pr`, `config`, `mode`, `prAction`, `failOnError`): `Promise`\<`void`\>
+
+Defined in: [jira.ts:103](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/jira.ts#L103)
+
+## Parameters
+
+### keys
+
+`string`[]
+
+### pr
+
+[`PrContext`](../../types/interfaces/PrContext.md)
+
+### config
+
+[`JiraConfig`](../../types/interfaces/JiraConfig.md)
+
+### mode
+
+[`JiraCommentMode`](../../types/type-aliases/JiraCommentMode.md)
+
+### prAction
+
+`string`
+
+### failOnError
+
+`boolean`
+
+## Returns
+
+`Promise`\<`void`\>

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,16 @@
+[**jira-action-man**](README.md)
+
+***
+
+# jira-action-man
+
+## Documents
+
+- [Configuration](documents/Configuration.md)
+
+## Modules
+
+- [extract](extract/README.md)
+- [jira](jira/README.md)
+- [sources](sources/README.md)
+- [types](types/README.md)

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -1,0 +1,12 @@
+[**jira-action-man**](../README.md)
+
+***
+
+[jira-action-man](../modules.md) / sources
+
+# sources
+
+## Functions
+
+- [collectSourceTexts](functions/collectSourceTexts.md)
+- [sourceTextsToArray](functions/sourceTextsToArray.md)

--- a/docs/sources/functions/collectSourceTexts.md
+++ b/docs/sources/functions/collectSourceTexts.md
@@ -1,0 +1,21 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [sources](../README.md) / collectSourceTexts
+
+# Function: collectSourceTexts()
+
+> **collectSourceTexts**(`requestedSources`): [`SourceTexts`](../../types/interfaces/SourceTexts.md)
+
+Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/sources.ts#L5)
+
+## Parameters
+
+### requestedSources
+
+[`Source`](../../types/type-aliases/Source.md)[]
+
+## Returns
+
+[`SourceTexts`](../../types/interfaces/SourceTexts.md)

--- a/docs/sources/functions/sourceTextsToArray.md
+++ b/docs/sources/functions/sourceTextsToArray.md
@@ -1,0 +1,21 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [sources](../README.md) / sourceTextsToArray
+
+# Function: sourceTextsToArray()
+
+> **sourceTextsToArray**(`texts`): `string`[]
+
+Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/sources.ts#L93)
+
+## Parameters
+
+### texts
+
+[`SourceTexts`](../../types/interfaces/SourceTexts.md)
+
+## Returns
+
+`string`[]

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -1,0 +1,19 @@
+[**jira-action-man**](../README.md)
+
+***
+
+[jira-action-man](../modules.md) / types
+
+# types
+
+## Interfaces
+
+- [ActionInputs](interfaces/ActionInputs.md)
+- [JiraConfig](interfaces/JiraConfig.md)
+- [PrContext](interfaces/PrContext.md)
+- [SourceTexts](interfaces/SourceTexts.md)
+
+## Type Aliases
+
+- [JiraCommentMode](type-aliases/JiraCommentMode.md)
+- [Source](type-aliases/Source.md)

--- a/docs/types/interfaces/ActionInputs.md
+++ b/docs/types/interfaces/ActionInputs.md
@@ -1,0 +1,73 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / ActionInputs
+
+# Interface: ActionInputs
+
+Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L5)
+
+## Properties
+
+### blocklist
+
+> **blocklist**: `string`[]
+
+Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L9)
+
+***
+
+### failOnMissing
+
+> **failOnMissing**: `boolean`
+
+Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L8)
+
+***
+
+### from
+
+> **from**: [`Source`](../type-aliases/Source.md)[]
+
+Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L7)
+
+***
+
+### issuePattern
+
+> **issuePattern**: `RegExp`
+
+Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L10)
+
+***
+
+### jiraCommentMode
+
+> **jiraCommentMode**: [`JiraCommentMode`](../type-aliases/JiraCommentMode.md)
+
+Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L12)
+
+***
+
+### jiraFailOnError
+
+> **jiraFailOnError**: `boolean`
+
+Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L13)
+
+***
+
+### postToJira
+
+> **postToJira**: `boolean`
+
+Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L11)
+
+***
+
+### projects
+
+> **projects**: `string`[]
+
+Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L6)

--- a/docs/types/interfaces/JiraConfig.md
+++ b/docs/types/interfaces/JiraConfig.md
@@ -1,0 +1,33 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / JiraConfig
+
+# Interface: JiraConfig
+
+Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L16)
+
+## Properties
+
+### apiToken
+
+> **apiToken**: `string`
+
+Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L19)
+
+***
+
+### baseUrl
+
+> **baseUrl**: `string`
+
+Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L17)
+
+***
+
+### email
+
+> **email**: `string`
+
+Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L18)

--- a/docs/types/interfaces/PrContext.md
+++ b/docs/types/interfaces/PrContext.md
@@ -1,0 +1,41 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / PrContext
+
+# Interface: PrContext
+
+Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L22)
+
+## Properties
+
+### body
+
+> **body**: `string`
+
+Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L25)
+
+***
+
+### number
+
+> **number**: `number`
+
+Defined in: [types.ts:23](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L23)
+
+***
+
+### title
+
+> **title**: `string`
+
+Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L24)
+
+***
+
+### url
+
+> **url**: `string`
+
+Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L26)

--- a/docs/types/interfaces/SourceTexts.md
+++ b/docs/types/interfaces/SourceTexts.md
@@ -1,0 +1,41 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / SourceTexts
+
+# Interface: SourceTexts
+
+Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L29)
+
+## Properties
+
+### body?
+
+> `optional` **body**: `string`
+
+Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L33)
+
+***
+
+### branch?
+
+> `optional` **branch**: `string`
+
+Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L30)
+
+***
+
+### commits?
+
+> `optional` **commits**: `string`[]
+
+Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L32)
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L31)

--- a/docs/types/type-aliases/JiraCommentMode.md
+++ b/docs/types/type-aliases/JiraCommentMode.md
@@ -1,0 +1,11 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / JiraCommentMode
+
+# Type Alias: JiraCommentMode
+
+> **JiraCommentMode** = `"update"` \| `"new"` \| `"minimal"`
+
+Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L3)

--- a/docs/types/type-aliases/Source.md
+++ b/docs/types/type-aliases/Source.md
@@ -1,0 +1,11 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / Source
+
+# Type Alias: Source
+
+> **Source** = `"branch"` \| `"title"` \| `"commits"` \| `"body"`
+
+Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L1)

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,62 @@
+---
+title: Configuration
+---
+
+# Configuration
+
+## Action Inputs
+
+### Key Extraction
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `projects` | `""` (match all) | Comma-separated Jira project prefixes to match (e.g. `"PROJ,TEAM"`) |
+| `from` | `"branch,title,commits"` | Comma-separated sources to check: `branch`, `title`, `commits`, `body` |
+| `fail_on_missing` | `"false"` | Fail the action if no Jira keys are found |
+| `blocklist` | `""` (use defaults) | Comma-separated prefixes to ignore. Set to `"none"` to disable |
+| `issue_pattern` | built-in regex | Custom regex pattern for matching issue keys |
+
+### Jira Comment Posting
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `post_to_jira` | `"false"` | Post PR description as a comment on linked Jira tickets |
+| `jira_base_url` | `""` | Jira instance base URL (e.g. `https://yourorg.atlassian.net`) |
+| `jira_email` | `""` | Jira account email for API authentication |
+| `jira_api_token` | `""` | Jira API token for authentication |
+| `jira_comment_mode` | `"update"` | Comment behavior: `update`, `new`, or `minimal` |
+| `jira_fail_on_error` | `"false"` | Fail the action if posting to Jira fails |
+| `github_token` | `""` | GitHub token for modifying PRs |
+
+## Comment Modes
+
+The `jira_comment_mode` input controls how comments are posted to Jira tickets:
+
+- **`update`** — Searches for an existing comment containing the PR URL. If found, updates it in place. If not, creates a new comment. This is the default and avoids duplicate comments on re-runs.
+- **`new`** — Always creates a new comment. Use this if you want a comment trail showing each push.
+- **`minimal`** — Posts a single-line comment with just the PR link instead of the full description.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `keys` | JSON array of unique sorted Jira issue keys (e.g. `["PROJ-1","PROJ-23"]`) |
+| `key` | First Jira issue key found (convenience for single-ticket workflows) |
+| `found` | `"true"` if any keys were found, `"false"` otherwise |
+
+## Example Workflow
+
+```yaml
+- uses: procyon-creative/jira-action-man@v1
+  id: jira
+  with:
+    projects: "PROJ,TEAM"
+    from: "branch,title,commits,body"
+    post_to_jira: "true"
+    jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+    jira_email: ${{ secrets.JIRA_EMAIL }}
+    jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+
+- run: echo "Found keys: ${{ steps.jira.outputs.keys }}"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "prettier": "^3.8.1",
         "ts-jest": "^29.1.2",
         "tsx": "^4.21.0",
+        "typedoc": "^0.28.17",
+        "typedoc-plugin-markdown": "^4.10.0",
         "typescript": "^5.4.5"
       }
     },
@@ -1159,6 +1161,20 @@
         "node": ">=14"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1738,6 +1754,55 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1834,6 +1899,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1893,6 +1968,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2950,6 +3032,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -4679,6 +4774,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.2.7",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
@@ -4958,6 +5063,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -5004,6 +5116,31 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -5015,6 +5152,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5436,6 +5580,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6088,6 +6242,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+      "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.17.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.10.0.tgz",
+      "integrity": "sha512-psrg8Rtnv4HPWCsoxId+MzEN8TVK5jeKCnTbnGAbTBqcDapR9hM41bJT/9eAyKn9C2MDG9Qjh3MkltAYuLDoXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6101,6 +6318,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint --fix src/ tests/",
+    "docs": "typedoc",
     "package": "npm run typecheck && npm test && npm run build",
     "test:jira": "tsx scripts/test-jira-post.ts",
     "prepare": "husky"
@@ -32,6 +33,8 @@
     "prettier": "^3.8.1",
     "ts-jest": "^29.1.2",
     "tsx": "^4.21.0",
+    "typedoc": "^0.28.17",
+    "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "^5.4.5"
   },
   "jest": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/types.ts",
+    "src/extract.ts",
+    "src/sources.ts",
+    "src/jira.ts"
+  ],
+  "plugin": ["typedoc-plugin-markdown"],
+  "out": "docs",
+  "projectDocuments": ["guides/*.md"],
+  "githubPages": false
+}


### PR DESCRIPTION
## Summary
- Add typedoc + typedoc-plugin-markdown to generate markdown API docs from source code into `docs/`
- Include a hand-written configuration guide (`guides/configuration.md`) covering action inputs, comment modes, and example workflows
- Auto-regenerate docs on every commit via husky pre-commit hook (`npm run docs && git add docs/`)

## Test plan
- [x] `npm run docs` generates `docs/` with markdown files for all 4 modules
- [x] `docs/modules.md` links to API modules and the configuration guide
- [x] `docs/documents/Configuration.md` contains the guide content
- [x] `npm run package` still passes (typecheck + 57 tests + build)
- [x] Pre-commit hook triggers doc regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)