### PR TITLE
JAM-8: Address PR review feedback on image upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,11 @@ index.ts → parseInputs() → collectSourceTexts() → extractKeysFromTexts() �
 
 Husky runs lint-staged: ESLint + Prettier on `*.ts`, Prettier on `*.{json,yml,yaml}`.
 
+## Code Style Preferences
+
+- **Prefer libraries over hand-rolled regex.** Regex is hard to read and easy to get wrong. Use established parsing libraries (e.g. a markdown parser for extracting structure, `content-type` package for parsing headers) instead of writing custom regex. The Jira issue key pattern in `extract.ts` is an exception since it's domain-specific.
+- **Use platform APIs over manual construction.** For example, use `FormData` instead of manually building multipart boundaries.
+
 ## Build Output
 
 `dist/index.js` is the NCC-bundled file committed to the repo — this is what GitHub Actions consumers run. Rebuild with `npm run build` after any source changes.

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,11 @@ inputs:
     required: false
     default: "false"
   github_token:
-    description: "GitHub token for modifying PRs. Usually secrets.GITHUB_TOKEN."
+    description: "GitHub token for downloading GitHub-hosted images in PR bodies and authenticating API requests. Usually secrets.GITHUB_TOKEN."
+    required: false
+    default: ""
+  allowed_image_hosts:
+    description: 'Comma-separated hostnames allowed for image downloads (e.g. "user-images.githubusercontent.com,example.com"). When set, only these hosts are permitted. When empty, all non-private HTTPS hosts are allowed.'
     required: false
     default: ""
 

--- a/dist/jira.d.ts
+++ b/dist/jira.d.ts
@@ -2,11 +2,27 @@ import { JiraCommentMode, JiraConfig, PrContext } from "./types";
 interface ImageRef {
   alt: string;
   url: string;
+  raw: string;
 }
 export declare function extractImageUrls(markdown: string): ImageRef[];
+export declare function replaceImageUrls(
+  markdown: string,
+  urlToFilename: Map<string, string>,
+): string;
+export declare function isSafeUrl(
+  url: string,
+  allowedHosts?: string[],
+): boolean;
+export declare function deduplicateFilenames(
+  entries: {
+    url: string;
+    filename: string;
+  }[],
+): Map<string, string>;
 export declare function downloadImage(
   url: string,
   githubToken?: string,
+  allowedHosts?: string[],
 ): Promise<{
   buffer: Buffer;
   filename: string;
@@ -19,10 +35,6 @@ export declare function uploadAttachment(
   contentType: string,
   config: JiraConfig,
 ): Promise<boolean>;
-export declare function replaceImageUrls(
-  markdown: string,
-  urlToFilename: Map<string, string>,
-): string;
 export declare function postToJira(
   keys: string[],
   pr: PrContext,
@@ -31,5 +43,6 @@ export declare function postToJira(
   prAction: string,
   failOnError: boolean,
   githubToken?: string,
+  allowedHosts?: string[],
 ): Promise<void>;
 export {};

--- a/docs/extract/functions/extractKeys.md
+++ b/docs/extract/functions/extractKeys.md
@@ -8,7 +8,7 @@
 
 > **extractKeys**(`text`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L34)
+Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/extract.ts#L34)
 
 ## Parameters
 

--- a/docs/extract/functions/extractKeysFromTexts.md
+++ b/docs/extract/functions/extractKeysFromTexts.md
@@ -8,7 +8,7 @@
 
 > **extractKeysFromTexts**(`texts`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L51)
+Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/extract.ts#L51)
 
 ## Parameters
 

--- a/docs/extract/functions/mergeAndSort.md
+++ b/docs/extract/functions/mergeAndSort.md
@@ -8,7 +8,7 @@
 
 > **mergeAndSort**(`keys`): `string`[]
 
-Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L63)
+Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/extract.ts#L63)
 
 ## Parameters
 

--- a/docs/extract/variables/DEFAULT_BLOCKLIST.md
+++ b/docs/extract/variables/DEFAULT_BLOCKLIST.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_BLOCKLIST**: `string`[]
 
-Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L4)
+Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/extract.ts#L4)

--- a/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
+++ b/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_ISSUE\_PATTERN**: `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"` = `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"`
 
-Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/extract.ts#L1)
+Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/extract.ts#L1)

--- a/docs/jira/README.md
+++ b/docs/jira/README.md
@@ -8,4 +8,10 @@
 
 ## Functions
 
+- [deduplicateFilenames](functions/deduplicateFilenames.md)
+- [downloadImage](functions/downloadImage.md)
+- [extractImageUrls](functions/extractImageUrls.md)
+- [isSafeUrl](functions/isSafeUrl.md)
 - [postToJira](functions/postToJira.md)
+- [replaceImageUrls](functions/replaceImageUrls.md)
+- [uploadAttachment](functions/uploadAttachment.md)

--- a/docs/jira/functions/deduplicateFilenames.md
+++ b/docs/jira/functions/deduplicateFilenames.md
@@ -1,0 +1,21 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / deduplicateFilenames
+
+# Function: deduplicateFilenames()
+
+> **deduplicateFilenames**(`entries`): `Map`\<`string`, `string`\>
+
+Defined in: [jira.ts:124](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L124)
+
+## Parameters
+
+### entries
+
+`object`[]
+
+## Returns
+
+`Map`\<`string`, `string`\>

--- a/docs/jira/functions/downloadImage.md
+++ b/docs/jira/functions/downloadImage.md
@@ -1,0 +1,29 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / downloadImage
+
+# Function: downloadImage()
+
+> **downloadImage**(`url`, `githubToken?`, `allowedHosts?`): `Promise`\<\{ `buffer`: `Buffer`; `contentType`: `string`; `filename`: `string`; \} \| `null`\>
+
+Defined in: [jira.ts:153](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L153)
+
+## Parameters
+
+### url
+
+`string`
+
+### githubToken?
+
+`string`
+
+### allowedHosts?
+
+`string`[]
+
+## Returns
+
+`Promise`\<\{ `buffer`: `Buffer`; `contentType`: `string`; `filename`: `string`; \} \| `null`\>

--- a/docs/jira/functions/extractImageUrls.md
+++ b/docs/jira/functions/extractImageUrls.md
@@ -1,0 +1,21 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / extractImageUrls
+
+# Function: extractImageUrls()
+
+> **extractImageUrls**(`markdown`): `ImageRef`[]
+
+Defined in: [jira.ts:35](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L35)
+
+## Parameters
+
+### markdown
+
+`string`
+
+## Returns
+
+`ImageRef`[]

--- a/docs/jira/functions/isSafeUrl.md
+++ b/docs/jira/functions/isSafeUrl.md
@@ -1,0 +1,25 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / isSafeUrl
+
+# Function: isSafeUrl()
+
+> **isSafeUrl**(`url`, `allowedHosts?`): `boolean`
+
+Defined in: [jira.ts:79](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L79)
+
+## Parameters
+
+### url
+
+`string`
+
+### allowedHosts?
+
+`string`[]
+
+## Returns
+
+`boolean`

--- a/docs/jira/functions/postToJira.md
+++ b/docs/jira/functions/postToJira.md
@@ -6,9 +6,9 @@
 
 # Function: postToJira()
 
-> **postToJira**(`keys`, `pr`, `config`, `mode`, `prAction`, `failOnError`): `Promise`\<`void`\>
+> **postToJira**(`keys`, `pr`, `config`, `mode`, `prAction`, `failOnError`, `githubToken?`, `allowedHosts?`): `Promise`\<`void`\>
 
-Defined in: [jira.ts:103](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/jira.ts#L103)
+Defined in: [jira.ts:350](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L350)
 
 ## Parameters
 
@@ -35,6 +35,14 @@ Defined in: [jira.ts:103](https://github.com/procyon-creative/jira-action-man/bl
 ### failOnError
 
 `boolean`
+
+### githubToken?
+
+`string`
+
+### allowedHosts?
+
+`string`[]
 
 ## Returns
 

--- a/docs/jira/functions/replaceImageUrls.md
+++ b/docs/jira/functions/replaceImageUrls.md
@@ -1,0 +1,25 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / replaceImageUrls
+
+# Function: replaceImageUrls()
+
+> **replaceImageUrls**(`markdown`, `urlToFilename`): `string`
+
+Defined in: [jira.ts:46](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L46)
+
+## Parameters
+
+### markdown
+
+`string`
+
+### urlToFilename
+
+`Map`\<`string`, `string`\>
+
+## Returns
+
+`string`

--- a/docs/jira/functions/uploadAttachment.md
+++ b/docs/jira/functions/uploadAttachment.md
@@ -1,0 +1,37 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / uploadAttachment
+
+# Function: uploadAttachment()
+
+> **uploadAttachment**(`issueKey`, `filename`, `buffer`, `contentType`, `config`): `Promise`\<`boolean`\>
+
+Defined in: [jira.ts:218](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/jira.ts#L218)
+
+## Parameters
+
+### issueKey
+
+`string`
+
+### filename
+
+`string`
+
+### buffer
+
+`Buffer`
+
+### contentType
+
+`string`
+
+### config
+
+[`JiraConfig`](../../types/interfaces/JiraConfig.md)
+
+## Returns
+
+`Promise`\<`boolean`\>

--- a/docs/sources/functions/collectSourceTexts.md
+++ b/docs/sources/functions/collectSourceTexts.md
@@ -8,7 +8,7 @@
 
 > **collectSourceTexts**(`requestedSources`): [`SourceTexts`](../../types/interfaces/SourceTexts.md)
 
-Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/sources.ts#L5)
+Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/sources.ts#L5)
 
 ## Parameters
 

--- a/docs/sources/functions/sourceTextsToArray.md
+++ b/docs/sources/functions/sourceTextsToArray.md
@@ -8,7 +8,7 @@
 
 > **sourceTextsToArray**(`texts`): `string`[]
 
-Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/sources.ts#L93)
+Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/sources.ts#L93)
 
 ## Parameters
 

--- a/docs/types/interfaces/ActionInputs.md
+++ b/docs/types/interfaces/ActionInputs.md
@@ -6,7 +6,7 @@
 
 # Interface: ActionInputs
 
-Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L5)
+Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blo
 
 > **blocklist**: `string`[]
 
-Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L9)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blo
 
 > **failOnMissing**: `boolean`
 
-Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L8)
+Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L8)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blo
 
 > **from**: [`Source`](../type-aliases/Source.md)[]
 
-Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L7)
+Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L7)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blo
 
 > **issuePattern**: `RegExp`
 
-Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L10)
+Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L10)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraCommentMode**: [`JiraCommentMode`](../type-aliases/JiraCommentMode.md)
 
-Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L12)
+Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L12)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraFailOnError**: `boolean`
 
-Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L13)
+Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L13)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/bl
 
 > **postToJira**: `boolean`
 
-Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L11)
+Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L11)
 
 ***
 
@@ -70,4 +70,4 @@ Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/bl
 
 > **projects**: `string`[]
 
-Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L6)
+Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L6)

--- a/docs/types/interfaces/JiraConfig.md
+++ b/docs/types/interfaces/JiraConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: JiraConfig
 
-Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L16)
+Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L16)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/bl
 
 > **apiToken**: `string`
 
-Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L19)
+Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L19)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/bl
 
 > **baseUrl**: `string`
 
-Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L17)
+Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L17)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/bl
 
 > **email**: `string`
 
-Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L18)
+Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L18)

--- a/docs/types/interfaces/PrContext.md
+++ b/docs/types/interfaces/PrContext.md
@@ -6,7 +6,7 @@
 
 # Interface: PrContext
 
-Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L22)
+Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L22)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/bl
 
 > **body**: `string`
 
-Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L25)
+Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L25)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/bl
 
 > **number**: `number`
 
-Defined in: [types.ts:23](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L23)
+Defined in: [types.ts:23](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L23)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:23](https://github.com/procyon-creative/jira-action-man/bl
 
 > **title**: `string`
 
-Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L24)
+Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L24)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/bl
 
 > **url**: `string`
 
-Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L26)
+Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L26)

--- a/docs/types/interfaces/SourceTexts.md
+++ b/docs/types/interfaces/SourceTexts.md
@@ -6,7 +6,7 @@
 
 # Interface: SourceTexts
 
-Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L29)
+Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L29)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **body**: `string`
 
-Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L33)
+Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L33)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **branch**: `string`
 
-Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L30)
+Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L30)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **commits**: `string`[]
 
-Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L32)
+Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L32)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **title**: `string`
 
-Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L31)
+Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L31)

--- a/docs/types/type-aliases/JiraCommentMode.md
+++ b/docs/types/type-aliases/JiraCommentMode.md
@@ -8,4 +8,4 @@
 
 > **JiraCommentMode** = `"update"` \| `"new"` \| `"minimal"`
 
-Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L3)
+Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L3)

--- a/docs/types/type-aliases/Source.md
+++ b/docs/types/type-aliases/Source.md
@@ -8,4 +8,4 @@
 
 > **Source** = `"branch"` \| `"title"` \| `"commits"` \| `"body"`
 
-Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/f1cb3edc20aba5e25a575d010bdaec3b7026319d/src/types.ts#L1)
+Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/ec8e53e5639ff626b77256a9793c0a5912c45a97/src/types.ts#L1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
-        "jira2md": "^3.0.1"
+        "jira2md": "^3.0.1",
+        "marked": "^4.3.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/marked": "^4.3.2",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vercel/ncc": "^0.38.1",
@@ -1951,6 +1953,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "jira2md": "^3.0.1"
+    "jira2md": "^3.0.1",
+    "marked": "^4.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/marked": "^4.3.2",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@vercel/ncc": "^0.38.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,13 @@ async function run(): Promise<void> {
 
           const prAction = (context.payload.action as string) || "opened";
           const githubToken = core.getInput("github_token") || undefined;
+          const allowedHostsRaw = core.getInput("allowed_image_hosts");
+          const allowedHosts = allowedHostsRaw
+            ? allowedHostsRaw
+                .split(",")
+                .map((h) => h.trim().toLowerCase())
+                .filter(Boolean)
+            : undefined;
           await postToJira(
             keys,
             pr,
@@ -148,6 +155,7 @@ async function run(): Promise<void> {
             prAction,
             inputs.jiraFailOnError,
             githubToken,
+            allowedHosts,
           );
         }
       } else if (!isPr) {

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -1,11 +1,15 @@
 import * as core from "@actions/core";
 import j2m from "jira2md";
+import { marked } from "marked";
 import { JiraCommentMode, JiraConfig, PrContext } from "./types";
 
 interface ImageRef {
   alt: string;
   url: string;
+  raw: string;
 }
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const CONTENT_TYPE_TO_EXT: Record<string, string> = {
   "image/png": ".png",
@@ -15,14 +19,54 @@ const CONTENT_TYPE_TO_EXT: Record<string, string> = {
   "image/svg+xml": ".svg",
 };
 
+// RFC 1918 / loopback / link-local patterns for SSRF protection
+const PRIVATE_IP_PATTERNS = [
+  /^127\./, // loopback
+  /^10\./, // 10.0.0.0/8
+  /^172\.(1[6-9]|2\d|3[01])\./, // 172.16.0.0/12
+  /^192\.168\./, // 192.168.0.0/16
+  /^169\.254\./, // link-local
+  /^0\./, // 0.0.0.0/8
+  /^::1$/, // IPv6 loopback
+  /^fe80:/i, // IPv6 link-local
+  /^f[cd]/i, // IPv6 unique local (fc00::/7)
+];
+
 export function extractImageUrls(markdown: string): ImageRef[] {
   const results: ImageRef[] = [];
-  const regex = /!\[([^\]]*)\]\(([^)]+)\)/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(markdown)) !== null) {
-    results.push({ alt: match[1], url: match[2] });
-  }
+  const tokens = marked.lexer(markdown);
+  marked.walkTokens(tokens, (token) => {
+    if (token.type === "image") {
+      results.push({ alt: token.text, url: token.href, raw: token.raw });
+    }
+  });
   return results;
+}
+
+export function replaceImageUrls(
+  markdown: string,
+  urlToFilename: Map<string, string>,
+): string {
+  // Extract images to get their raw tokens, then replace in reverse order
+  // to preserve string positions
+  const images = extractImageUrls(markdown);
+  let result = markdown;
+  // Process in reverse so earlier replacements don't shift later positions
+  for (let i = images.length - 1; i >= 0; i--) {
+    const img = images[i];
+    const filename = urlToFilename.get(img.url);
+    if (filename) {
+      const replacement = `![${img.alt}](${filename})`;
+      const idx = result.lastIndexOf(img.raw);
+      if (idx !== -1) {
+        result =
+          result.slice(0, idx) +
+          replacement +
+          result.slice(idx + img.raw.length);
+      }
+    }
+  }
+  return result;
 }
 
 function isGitHubUrl(url: string): boolean {
@@ -34,24 +78,91 @@ function isGitHubUrl(url: string): boolean {
   }
 }
 
+export function isSafeUrl(url: string, allowedHosts?: string[]): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  // HTTPS only
+  if (parsed.protocol !== "https:") {
+    return false;
+  }
+
+  // If allowlist provided, only those hosts pass
+  if (allowedHosts && allowedHosts.length > 0) {
+    return allowedHosts.includes(parsed.hostname);
+  }
+
+  // Block private/loopback/link-local IPs
+  for (const pattern of PRIVATE_IP_PATTERNS) {
+    if (pattern.test(parsed.hostname)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function stripContentType(raw: string): string {
+  return raw.split(";")[0].trim();
+}
+
 function filenameFromUrl(url: string, contentType: string | null): string {
   const pathname = new URL(url).pathname;
   let basename = pathname.split("/").pop() || "image";
 
   const hasExt = /\.\w{2,5}$/.test(basename);
   if (!hasExt && contentType) {
-    const ext = CONTENT_TYPE_TO_EXT[contentType] || ".bin";
+    const ext = CONTENT_TYPE_TO_EXT[stripContentType(contentType)] || ".bin";
     basename += ext;
   }
 
   return basename;
 }
 
+export function deduplicateFilenames(
+  entries: { url: string; filename: string }[],
+): Map<string, string> {
+  // Count occurrences of each filename
+  const counts = new Map<string, number>();
+  for (const e of entries) {
+    counts.set(e.filename, (counts.get(e.filename) || 0) + 1);
+  }
+
+  // For colliding names, append -1, -2, etc.
+  const counters = new Map<string, number>();
+  const result = new Map<string, string>();
+  for (const e of entries) {
+    if ((counts.get(e.filename) || 0) > 1) {
+      const n = (counters.get(e.filename) || 0) + 1;
+      counters.set(e.filename, n);
+      const dotIdx = e.filename.lastIndexOf(".");
+      const dedupedName =
+        dotIdx !== -1
+          ? `${e.filename.slice(0, dotIdx)}-${n}${e.filename.slice(dotIdx)}`
+          : `${e.filename}-${n}`;
+      result.set(e.url, dedupedName);
+    } else {
+      result.set(e.url, e.filename);
+    }
+  }
+  return result;
+}
+
 export async function downloadImage(
   url: string,
   githubToken?: string,
+  allowedHosts?: string[],
 ): Promise<{ buffer: Buffer; filename: string; contentType: string } | null> {
   try {
+    if (!isSafeUrl(url, allowedHosts)) {
+      core.warning(`Blocked image download from unsafe URL: ${url}`);
+      return null;
+    }
+
     const headers: Record<string, string> = {};
     if (githubToken && isGitHubUrl(url)) {
       headers["Authorization"] = `token ${githubToken}`;
@@ -63,9 +174,38 @@ export async function downloadImage(
       return null;
     }
 
-    const contentType =
+    const rawContentType =
       response.headers.get("content-type") || "application/octet-stream";
-    const buffer = Buffer.from(await response.arrayBuffer());
+    const contentType = stripContentType(rawContentType);
+
+    // Validate content type is an image
+    if (!contentType.startsWith("image/")) {
+      core.warning(
+        `Rejected non-image content-type "${contentType}" from ${url}`,
+      );
+      return null;
+    }
+
+    // Check content-length before reading body
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && parseInt(contentLength, 10) > MAX_IMAGE_BYTES) {
+      core.warning(
+        `Rejected image from ${url}: content-length ${contentLength} exceeds ${MAX_IMAGE_BYTES} bytes`,
+      );
+      return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+
+    // Safety net: check actual size after reading
+    if (arrayBuffer.byteLength > MAX_IMAGE_BYTES) {
+      core.warning(
+        `Rejected image from ${url}: size ${arrayBuffer.byteLength} exceeds ${MAX_IMAGE_BYTES} bytes`,
+      );
+      return null;
+    }
+
+    const buffer = Buffer.from(arrayBuffer);
     const filename = filenameFromUrl(url, contentType);
 
     return { buffer, filename, contentType };
@@ -86,24 +226,20 @@ export async function uploadAttachment(
 ): Promise<boolean> {
   const url = `${config.baseUrl}/rest/api/2/issue/${issueKey}/attachments`;
 
-  const boundary = `----formdata-${Date.now()}`;
-  const header = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: ${contentType}\r\n\r\n`;
-  const footer = `\r\n--${boundary}--\r\n`;
-
-  const body = Buffer.concat([
-    Buffer.from(header),
-    buffer,
-    Buffer.from(footer),
-  ]);
+  const form = new FormData();
+  form.append(
+    "file",
+    new Blob([new Uint8Array(buffer)], { type: contentType }),
+    filename,
+  );
 
   const response = await fetch(url, {
     method: "POST",
     headers: {
       Authorization: authHeader(config),
       "X-Atlassian-Token": "no-check",
-      "Content-Type": `multipart/form-data; boundary=${boundary}`,
     },
-    body,
+    body: form,
   });
 
   if (!response.ok) {
@@ -113,19 +249,6 @@ export async function uploadAttachment(
     return false;
   }
   return true;
-}
-
-export function replaceImageUrls(
-  markdown: string,
-  urlToFilename: Map<string, string>,
-): string {
-  return markdown.replace(
-    /!\[([^\]]*)\]\(([^)]+)\)/g,
-    (original, alt: string, url: string) => {
-      const filename = urlToFilename.get(url);
-      return filename ? `![${alt}](${filename})` : original;
-    },
-  );
 }
 
 function buildFullBody(pr: PrContext): string {
@@ -234,6 +357,7 @@ export async function postToJira(
   prAction: string,
   failOnError: boolean,
   githubToken?: string,
+  allowedHosts?: string[],
 ): Promise<void> {
   config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
 
@@ -250,9 +374,22 @@ export async function postToJira(
     for (const img of images) {
       if (seenUrls.has(img.url)) continue;
       seenUrls.add(img.url);
-      const result = await downloadImage(img.url, githubToken);
+      const result = await downloadImage(img.url, githubToken, allowedHosts);
       if (result) {
         downloaded.set(img.url, result);
+      }
+    }
+
+    // Deduplicate filenames across all downloaded images
+    if (downloaded.size > 1) {
+      const entries = Array.from(downloaded, ([url, d]) => ({
+        url,
+        filename: d.filename,
+      }));
+      const dedupedNames = deduplicateFilenames(entries);
+      for (const [url, newName] of dedupedNames) {
+        const existing = downloaded.get(url)!;
+        existing.filename = newName;
       }
     }
   }


### PR DESCRIPTION
Replace hand-rolled regex with marked.lexer for image extraction, swap manual multipart construction for FormData, add SSRF protection, content-type validation, size limits, charset stripping, and filename deduplication. Add allowed_image_hosts action input.

## Summary

<img width="712" height="638" alt="bowie" src="https://github.com/user-attachments/assets/37d8b559-f8e3-4e30-9afb-eb193441eab7" />

<!-- What does this PR do and why? -->

## Test plan

<!-- How did you verify this works? -->

## Checklist

- [ ] `npm run package` passes (typecheck + tests + build)
- [ ] `dist/index.js` is rebuilt and committed
