### PR TITLE
JAM-10/11: Bump to Node 24 LTS and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -65,5 +65,5 @@ outputs:
     description: '"true" if any keys were found, "false" otherwise'
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Summary

Two related ticket: keeping the runtime fresh and automating future bumps.

**JAM-10** — Bump Node from 20 to 24 (current Active LTS).
- `action.yml`: `using: "node20"` → `"node24"`. Note: GitHub Actions only supports `node20` and `node24` for `runs.using` — `node22` is not an option.
- `.github/workflows/ci.yml`: `node-version: 20` → `24`.

**JAM-11** — Add `.github/dependabot.yml`.
- Weekly schedule for both `npm` and `github-actions` ecosystems.
- npm: groups dev vs production deps (minor + patch) to avoid PR noise.
- 5 open PR cap per ecosystem.

## Test plan

- [x] `npm run package` passes locally (typecheck + 93 tests + build)
- [ ] CI green on this PR
- [ ] Confirm action still runs in the dogfood job after merge

## Notes

Once merged, Dependabot will start opening update PRs on its first run. You may want to enable auto-merge for patch-level groups if the noise becomes an issue.

Closes JAM-10, JAM-11.