### PR TITLE
JAM-9: Add v1 major version tag auto-update workflow

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -46,6 +46,12 @@ jobs:
             target="$INPUT_TARGET"
             major="$INPUT_MAJOR"
           fi
+          # Reject anything that isn't a clean vMAJOR tag — protects against
+          # typos or misuse force-pushing over unrelated refs.
+          if [[ ! "$major" =~ ^v[0-9]+$ ]]; then
+            echo "Refusing to move tag '$major': expected pattern ^v[0-9]+$"
+            exit 1
+          fi
           echo "target=$target" >> "$GITHUB_OUTPUT"
           echo "major=$major"  >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,0 +1,62 @@
+name: Update Major Version Tag
+run-name: ${{ github.event_name == 'release' && format('Move major tag for release {0}', github.event.release.tag_name) || format('Move {0} to {1}', github.event.inputs.major_version, github.event.inputs.target) }}
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "The tag or reference to point the major version at (e.g. v1.2.3)"
+        required: true
+      major_version:
+        description: "The major version tag to move (e.g. v1)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: vars
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TARGET: ${{ github.event.inputs.target }}
+          INPUT_MAJOR: ${{ github.event.inputs.major_version }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            target="$RELEASE_TAG"
+            # Extract leading vN from a semver tag like v1.2.3, v1.2.3-alpha, etc.
+            if [[ "$target" =~ ^(v[0-9]+)\. ]]; then
+              major="${BASH_REMATCH[1]}"
+            else
+              echo "Release tag '$target' does not look like vMAJOR.MINOR.PATCH; skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            target="$INPUT_TARGET"
+            major="$INPUT_MAJOR"
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "major=$major"  >> "$GITHUB_OUTPUT"
+
+      - name: Git config
+        if: steps.vars.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Move major tag
+        if: steps.vars.outputs.skip != 'true'
+        run: |
+          git tag -f "${{ steps.vars.outputs.major }}" "${{ steps.vars.outputs.target }}"
+          git push origin "${{ steps.vars.outputs.major }}" --force

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts posts
 ## Quick Start
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ,TEAM"
@@ -59,7 +59,7 @@ Keys are sorted alphabetically by project prefix, then numerically by issue numb
 ### Pull Request with Multiple Sources
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ"
@@ -70,7 +70,7 @@ Keys are sorted alphabetically by project prefix, then numerically by issue numb
 ### Use Extracted Keys in Later Steps
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ,TEAM"
@@ -92,7 +92,7 @@ When `post_to_jira` is enabled on `pull_request` events, the action posts the PR
 | `minimal` | Creates a single-line link to the PR. Low noise. |
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ"


### PR DESCRIPTION
## Summary

Add a workflow that moves the major version tag (\`v1\`) automatically on each release, so consumers can pin to \`@v1\` and get patch/minor updates for free — the standard GitHub Actions distribution pattern (cf. actions/checkout).

- **\`.github/workflows/update-main-version.yml\`** — Triggers on \`release.published\`. Extracts the major version from the release tag (e.g. \`v1\` from \`v1.2.3\`) and force-pushes the major tag to point at it. Also supports manual \`workflow_dispatch\` with explicit \`target\` and \`major_version\` inputs as an escape hatch.
- **README** — All \`@main\` usage examples switched to \`@v1\`.

## One-time setup after merge

The initial \`v1\` tag has to be created by hand (the workflow only *moves* it):

\`\`\`bash
git tag v1 v1.0.0
git push origin v1
\`\`\`

After that, every \`v1.x.y\` release triggers the workflow and moves \`v1\` forward automatically.

## Notes

- The workflow uses \`permissions: contents: write\` rather than a PAT — \`GITHUB_TOKEN\` can force-push tags as long as branch protection rules don't restrict tag pushes.
- If a pre-release like \`v1.2.0-rc.1\` is published, it will still move \`v1\` (matches \`v1.\` prefix). Pre-releases can be excluded later if that's undesirable.

## Test plan

- [ ] After merging, manually run the workflow with \`target=v1.0.0\` \`major_version=v1\` to seed \`v1\`
- [ ] On the next release, verify the workflow runs and \`v1\` points at the new tag

Closes JAM-9.