### PR TITLE
Cleanup: README typo, doc refresh, consolidate input parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A GitHub Action that extracts Jira issue keys from GitHub events and posts PR comments to Jira.
 
-- Node 20
+- Node 24
 - Extracts from branch names, PR titles, commit messages, and PR body
 - Posts PR descriptions as comments on linked Jira tickets (with update-on-rerun dedup)
 - Uploads PR body images to Jira as attachments (with SSRF protection and size limits)

--- a/dist/index.js
+++ b/dist/index.js
@@ -30282,6 +30282,14 @@ function parseInputs() {
         ? jiraCommentModeRaw
         : "update");
     const jiraFailOnError = core.getInput("jira_fail_on_error") === "true";
+    const githubToken = core.getInput("github_token") || undefined;
+    const allowedHostsRaw = core.getInput("allowed_image_hosts");
+    const allowedImageHosts = allowedHostsRaw
+        ? allowedHostsRaw
+            .split(",")
+            .map((h) => h.trim().toLowerCase())
+            .filter(Boolean)
+        : undefined;
     return {
         projects,
         from,
@@ -30291,6 +30299,8 @@ function parseInputs() {
         postToJira,
         jiraCommentMode,
         jiraFailOnError,
+        githubToken,
+        allowedImageHosts,
     };
 }
 async function run() {
@@ -30350,15 +30360,7 @@ async function run() {
                         url: prPayload.html_url,
                     };
                     const prAction = context.payload.action || "opened";
-                    const githubToken = core.getInput("github_token") || undefined;
-                    const allowedHostsRaw = core.getInput("allowed_image_hosts");
-                    const allowedHosts = allowedHostsRaw
-                        ? allowedHostsRaw
-                            .split(",")
-                            .map((h) => h.trim().toLowerCase())
-                            .filter(Boolean)
-                        : undefined;
-                    await (0, jira_1.postToJira)(keys, pr, jiraConfig, inputs.jiraCommentMode, prAction, inputs.jiraFailOnError, githubToken, allowedHosts);
+                    await (0, jira_1.postToJira)(keys, pr, jiraConfig, inputs.jiraCommentMode, prAction, inputs.jiraFailOnError, inputs.githubToken, inputs.allowedImageHosts);
                 }
             }
             else if (!isPr) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 A GitHub Action that extracts Jira issue keys from GitHub events and posts PR comments to Jira.
 
-- Node 20
+- Node 24
 - Extracts from branch names, PR titles, commit messages, and PR body
 - Posts PR descriptions as comments on linked Jira tickets (with update-on-rerun dedup)
 - Uploads PR body images to Jira as attachments (with SSRF protection and size limits)
@@ -15,7 +15,7 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 ## Quick Start
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ,TEAM"
@@ -65,7 +65,7 @@ Keys are sorted alphabetically by project prefix, then numerically by issue numb
 ### Pull Request with Multiple Sources
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ"
@@ -76,7 +76,7 @@ Keys are sorted alphabetically by project prefix, then numerically by issue numb
 ### Use Extracted Keys in Later Steps
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ,TEAM"
@@ -98,7 +98,7 @@ When `post_to_jira` is enabled on `pull_request` events, the action posts the PR
 | `minimal` | Creates a single-line link to the PR. Low noise. |
 
 ```yaml
-- uses: procyon-creative/jira-action-man@main
+- uses: procyon-creative/jira-action-man@v1
   id: jira
   with:
     projects: "PROJ"

--- a/docs/extract/functions/extractKeys.md
+++ b/docs/extract/functions/extractKeys.md
@@ -8,7 +8,7 @@
 
 > **extractKeys**(`text`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/extract.ts#L34)
+Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L34)
 
 ## Parameters
 

--- a/docs/extract/functions/extractKeysFromTexts.md
+++ b/docs/extract/functions/extractKeysFromTexts.md
@@ -8,7 +8,7 @@
 
 > **extractKeysFromTexts**(`texts`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/extract.ts#L51)
+Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L51)
 
 ## Parameters
 

--- a/docs/extract/functions/mergeAndSort.md
+++ b/docs/extract/functions/mergeAndSort.md
@@ -8,7 +8,7 @@
 
 > **mergeAndSort**(`keys`): `string`[]
 
-Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/extract.ts#L63)
+Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L63)
 
 ## Parameters
 

--- a/docs/extract/variables/DEFAULT_BLOCKLIST.md
+++ b/docs/extract/variables/DEFAULT_BLOCKLIST.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_BLOCKLIST**: `string`[]
 
-Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/extract.ts#L4)
+Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L4)

--- a/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
+++ b/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_ISSUE\_PATTERN**: `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"` = `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"`
 
-Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/extract.ts#L1)
+Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L1)

--- a/docs/jira/functions/deduplicateFilenames.md
+++ b/docs/jira/functions/deduplicateFilenames.md
@@ -8,7 +8,7 @@
 
 > **deduplicateFilenames**(`entries`): `Map`\<`string`, `string`\>
 
-Defined in: [jira.ts:177](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L177)
+Defined in: [jira.ts:177](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L177)
 
 ## Parameters
 

--- a/docs/jira/functions/downloadImage.md
+++ b/docs/jira/functions/downloadImage.md
@@ -8,7 +8,7 @@
 
 > **downloadImage**(`url`, `githubToken?`, `allowedHosts?`): `Promise`\<\{ `buffer`: `Buffer`; `contentType`: `string`; `filename`: `string`; \} \| `null`\>
 
-Defined in: [jira.ts:213](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L213)
+Defined in: [jira.ts:213](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L213)
 
 ## Parameters
 

--- a/docs/jira/functions/extractImageUrls.md
+++ b/docs/jira/functions/extractImageUrls.md
@@ -8,7 +8,7 @@
 
 > **extractImageUrls**(`markdown`): `ImageRef`[]
 
-Defined in: [jira.ts:38](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L38)
+Defined in: [jira.ts:38](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L38)
 
 ## Parameters
 

--- a/docs/jira/functions/isPrivateIp.md
+++ b/docs/jira/functions/isPrivateIp.md
@@ -8,7 +8,7 @@
 
 > **isPrivateIp**(`ip`): `boolean`
 
-Defined in: [jira.ts:101](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L101)
+Defined in: [jira.ts:101](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L101)
 
 ## Parameters
 

--- a/docs/jira/functions/isSafeUrl.md
+++ b/docs/jira/functions/isSafeUrl.md
@@ -8,7 +8,7 @@
 
 > **isSafeUrl**(`url`, `allowedHosts?`): `Promise`\<`boolean`\>
 
-Defined in: [jira.ts:111](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L111)
+Defined in: [jira.ts:111](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L111)
 
 ## Parameters
 

--- a/docs/jira/functions/postToJira.md
+++ b/docs/jira/functions/postToJira.md
@@ -8,7 +8,7 @@
 
 > **postToJira**(`keys`, `pr`, `config`, `mode`, `prAction`, `failOnError`, `githubToken?`, `allowedHosts?`): `Promise`\<`void`\>
 
-Defined in: [jira.ts:422](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L422)
+Defined in: [jira.ts:422](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L422)
 
 ## Parameters
 

--- a/docs/jira/functions/replaceImageUrls.md
+++ b/docs/jira/functions/replaceImageUrls.md
@@ -8,7 +8,7 @@
 
 > **replaceImageUrls**(`markdown`, `urlToFilename`): `string`
 
-Defined in: [jira.ts:54](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L54)
+Defined in: [jira.ts:54](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L54)
 
 ## Parameters
 

--- a/docs/jira/functions/uploadAttachment.md
+++ b/docs/jira/functions/uploadAttachment.md
@@ -8,7 +8,7 @@
 
 > **uploadAttachment**(`issueKey`, `filename`, `buffer`, `contentType`, `config`): `Promise`\<`boolean`\>
 
-Defined in: [jira.ts:290](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/jira.ts#L290)
+Defined in: [jira.ts:290](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L290)
 
 ## Parameters
 

--- a/docs/sources/functions/collectSourceTexts.md
+++ b/docs/sources/functions/collectSourceTexts.md
@@ -8,7 +8,7 @@
 
 > **collectSourceTexts**(`requestedSources`): [`SourceTexts`](../../types/interfaces/SourceTexts.md)
 
-Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/sources.ts#L5)
+Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/sources.ts#L5)
 
 ## Parameters
 

--- a/docs/sources/functions/sourceTextsToArray.md
+++ b/docs/sources/functions/sourceTextsToArray.md
@@ -8,7 +8,7 @@
 
 > **sourceTextsToArray**(`texts`): `string`[]
 
-Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/sources.ts#L93)
+Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/sources.ts#L93)
 
 ## Parameters
 

--- a/docs/types/interfaces/ActionInputs.md
+++ b/docs/types/interfaces/ActionInputs.md
@@ -6,15 +6,23 @@
 
 # Interface: ActionInputs
 
-Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L5)
+Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L5)
 
 ## Properties
+
+### allowedImageHosts?
+
+> `optional` **allowedImageHosts**: `string`[]
+
+Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L15)
+
+***
 
 ### blocklist
 
 > **blocklist**: `string`[]
 
-Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L9)
 
 ***
 
@@ -22,7 +30,7 @@ Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blo
 
 > **failOnMissing**: `boolean`
 
-Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L8)
+Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L8)
 
 ***
 
@@ -30,7 +38,15 @@ Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blo
 
 > **from**: [`Source`](../type-aliases/Source.md)[]
 
-Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L7)
+Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L7)
+
+***
+
+### githubToken?
+
+> `optional` **githubToken**: `string`
+
+Defined in: [types.ts:14](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L14)
 
 ***
 
@@ -38,7 +54,7 @@ Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blo
 
 > **issuePattern**: `RegExp`
 
-Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L10)
+Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L10)
 
 ***
 
@@ -46,7 +62,7 @@ Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraCommentMode**: [`JiraCommentMode`](../type-aliases/JiraCommentMode.md)
 
-Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L12)
+Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L12)
 
 ***
 
@@ -54,7 +70,7 @@ Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraFailOnError**: `boolean`
 
-Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L13)
+Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L13)
 
 ***
 
@@ -62,7 +78,7 @@ Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/bl
 
 > **postToJira**: `boolean`
 
-Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L11)
+Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L11)
 
 ***
 
@@ -70,4 +86,4 @@ Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/bl
 
 > **projects**: `string`[]
 
-Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L6)
+Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L6)

--- a/docs/types/interfaces/JiraConfig.md
+++ b/docs/types/interfaces/JiraConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: JiraConfig
 
-Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L16)
+Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L18)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/bl
 
 > **apiToken**: `string`
 
-Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L19)
+Defined in: [types.ts:21](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L21)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/bl
 
 > **baseUrl**: `string`
 
-Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L17)
+Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L19)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/bl
 
 > **email**: `string`
 
-Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L18)
+Defined in: [types.ts:20](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L20)

--- a/docs/types/interfaces/PrContext.md
+++ b/docs/types/interfaces/PrContext.md
@@ -6,7 +6,7 @@
 
 # Interface: PrContext
 
-Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L22)
+Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L24)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/bl
 
 > **body**: `string`
 
-Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L25)
+Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L27)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/bl
 
 > **number**: `number`
 
-Defined in: [types.ts:23](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L23)
+Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L25)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:23](https://github.com/procyon-creative/jira-action-man/bl
 
 > **title**: `string`
 
-Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L24)
+Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L26)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/bl
 
 > **url**: `string`
 
-Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L26)
+Defined in: [types.ts:28](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L28)

--- a/docs/types/interfaces/SourceTexts.md
+++ b/docs/types/interfaces/SourceTexts.md
@@ -6,7 +6,7 @@
 
 # Interface: SourceTexts
 
-Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L29)
+Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L31)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **body**: `string`
 
-Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L33)
+Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L35)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **branch**: `string`
 
-Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L30)
+Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L32)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **commits**: `string`[]
 
-Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L32)
+Defined in: [types.ts:34](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L34)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **title**: `string`
 
-Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L31)
+Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L33)

--- a/docs/types/type-aliases/JiraCommentMode.md
+++ b/docs/types/type-aliases/JiraCommentMode.md
@@ -8,4 +8,4 @@
 
 > **JiraCommentMode** = `"update"` \| `"new"` \| `"minimal"`
 
-Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L3)
+Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L3)

--- a/docs/types/type-aliases/Source.md
+++ b/docs/types/type-aliases/Source.md
@@ -8,4 +8,4 @@
 
 > **Source** = `"branch"` \| `"title"` \| `"commits"` \| `"body"`
 
-Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/44ae233d3f47fd96af9faa7bf23e4de4831576ab/src/types.ts#L1)
+Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,16 @@ function parseInputs(): ActionInputs {
   ) as JiraCommentMode;
   const jiraFailOnError = core.getInput("jira_fail_on_error") === "true";
 
+  const githubToken = core.getInput("github_token") || undefined;
+
+  const allowedHostsRaw = core.getInput("allowed_image_hosts");
+  const allowedImageHosts = allowedHostsRaw
+    ? allowedHostsRaw
+        .split(",")
+        .map((h) => h.trim().toLowerCase())
+        .filter(Boolean)
+    : undefined;
+
   return {
     projects,
     from,
@@ -66,6 +76,8 @@ function parseInputs(): ActionInputs {
     postToJira,
     jiraCommentMode,
     jiraFailOnError,
+    githubToken,
+    allowedImageHosts,
   };
 }
 
@@ -139,14 +151,6 @@ async function run(): Promise<void> {
           };
 
           const prAction = (context.payload.action as string) || "opened";
-          const githubToken = core.getInput("github_token") || undefined;
-          const allowedHostsRaw = core.getInput("allowed_image_hosts");
-          const allowedHosts = allowedHostsRaw
-            ? allowedHostsRaw
-                .split(",")
-                .map((h) => h.trim().toLowerCase())
-                .filter(Boolean)
-            : undefined;
           await postToJira(
             keys,
             pr,
@@ -154,8 +158,8 @@ async function run(): Promise<void> {
             inputs.jiraCommentMode,
             prAction,
             inputs.jiraFailOnError,
-            githubToken,
-            allowedHosts,
+            inputs.githubToken,
+            inputs.allowedImageHosts,
           );
         }
       } else if (!isPr) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface ActionInputs {
   postToJira: boolean;
   jiraCommentMode: JiraCommentMode;
   jiraFailOnError: boolean;
+  githubToken?: string;
+  allowedImageHosts?: string[];
 }
 
 export interface JiraConfig {


### PR DESCRIPTION
## Summary

Follow-up cleanup based on Copilot review threads on the previous batch of PRs (none of which were on a Jira ticket).

- **README** — Drop the duplicate "posts posts" word in the intro; bump the "Node 20" version line to Node 24 to match the action.yml runtime.
- **src/index.ts + src/types.ts** — Move \`github_token\` and \`allowed_image_hosts\` parsing into \`parseInputs()\`. New optional \`githubToken\` and \`allowedImageHosts\` fields on \`ActionInputs\`. Run() now reads them from \`inputs.\*\` like every other input.
- **docs/** — Regenerate the Typedoc output so the published docs match the source README (drops \`@main\` references for \`@v1\`, picks up the Node 24 line, includes \`allowed_image_hosts\` in the inputs table).

## Test plan

- [x] \`npm run package\` passes (typecheck + 99 tests + build)
- [x] \`dist/index.js\` rebuilt and committed