### PR TITLE
feat: add transition_to input to move matched issues to a status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 | `jira_email` | `""` | Jira account email for API authentication |
 | `jira_api_token` | `""` | Jira API token for authentication |
 | `jira_comment_mode` | `update` | Comment behavior: `update`, `new`, or `minimal` (see below) |
-| `jira_fail_on_error` | `false` | Fail the action if posting to Jira fails (default: warn only) |
+| `jira_fail_on_error` | `false` | Fail the action if posting to Jira or transitioning an issue fails (default: warn only) |
+| `transition_to` | `""` | Status name to transition matched issues to (e.g. `QA`, `Done`). Empty = no transition (see below) |
 | `github_token` | `""` | GitHub token for downloading GitHub-hosted images in PR bodies |
 | `allowed_image_hosts` | `""` | Comma-separated hostnames allowed for image downloads (empty = all non-private HTTPS hosts) |
 
@@ -108,6 +109,41 @@ When `post_to_jira` is enabled on `pull_request` events, the action posts the PR
 ```
 
 Images in the PR body are automatically downloaded and uploaded to Jira as attachments. The image references in the comment are updated to point to the uploaded files. Only HTTPS URLs are allowed, and private/loopback IPs are blocked. Use `allowed_image_hosts` to restrict downloads to specific domains.
+
+### Transition Issues
+
+Set `transition_to` to a status name and the action moves every matched issue to that status (using `jira_base_url`/`jira_email`/`jira_api_token`). The status is matched case-insensitively against the issue's available transitions. If no matching transition exists for an issue, the action logs a warning and continues — it does not fail (unless `jira_fail_on_error: true`). Transitions are event-agnostic: they run wherever issue keys are found, independent of `post_to_jira`.
+
+A common pattern is one job that moves issues to a review column when a PR opens, and another that moves them to Done when it merges:
+
+```yaml
+jobs:
+  to-qa:
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: procyon-creative/jira-action-man@v2
+        with:
+          projects: "PROJ"
+          from: "branch,title,commits,body"
+          transition_to: "QA"
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_email: ${{ secrets.JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+
+  to-done:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: procyon-creative/jira-action-man@v2
+        with:
+          projects: "PROJ"
+          from: "branch,title,commits,body"
+          transition_to: "Done"
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_email: ${{ secrets.JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+```
 
 ## Blocklist
 

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,13 @@ inputs:
     required: false
     default: "update"
   jira_fail_on_error:
-    description: "Fail the action if posting to Jira fails (default: warn only)"
+    description: "Fail the action if posting to Jira or transitioning an issue fails (default: warn only)"
     required: false
     default: "false"
+  transition_to:
+    description: "Status name to transition matched issues to (e.g. 'QA', 'Done'). Empty = no transition. Uses jira_base_url/email/token; obeys jira_fail_on_error (warn by default)."
+    required: false
+    default: ""
   github_token:
     description: "GitHub token used to authorize image downloads from GitHub-hosted URLs in PR bodies. Usually secrets.GITHUB_TOKEN."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -30282,6 +30282,7 @@ function parseInputs() {
         ? jiraCommentModeRaw
         : "update");
     const jiraFailOnError = core.getInput("jira_fail_on_error") === "true";
+    const transitionTo = core.getInput("transition_to").trim() || undefined;
     const githubToken = core.getInput("github_token") || undefined;
     const allowedHostsRaw = core.getInput("allowed_image_hosts");
     const allowedImageHosts = allowedHostsRaw
@@ -30299,6 +30300,7 @@ function parseInputs() {
         postToJira,
         jiraCommentMode,
         jiraFailOnError,
+        transitionTo,
         githubToken,
         allowedImageHosts,
     };
@@ -30332,39 +30334,47 @@ async function run() {
                 core.info(msg);
             }
         }
-        if (inputs.postToJira && keys.length > 0) {
-            const { context } = github;
-            const isPr = context.eventName === "pull_request" ||
-                context.eventName === "pull_request_target";
-            if (isPr && context.payload.pull_request) {
-                const jiraConfig = {
-                    baseUrl: core.getInput("jira_base_url"),
-                    email: core.getInput("jira_email"),
-                    apiToken: core.getInput("jira_api_token"),
-                };
-                if (!jiraConfig.baseUrl || !jiraConfig.email || !jiraConfig.apiToken) {
-                    const msg = "post_to_jira is enabled but jira_base_url, jira_email, or jira_api_token is missing";
-                    if (inputs.jiraFailOnError) {
-                        core.setFailed(msg);
-                    }
-                    else {
-                        core.warning(msg);
-                    }
+        const needsJira = (inputs.postToJira || !!inputs.transitionTo) && keys.length > 0;
+        if (needsJira) {
+            const jiraConfig = {
+                baseUrl: core.getInput("jira_base_url"),
+                email: core.getInput("jira_email"),
+                apiToken: core.getInput("jira_api_token"),
+            };
+            if (!jiraConfig.baseUrl || !jiraConfig.email || !jiraConfig.apiToken) {
+                const msg = "post_to_jira/transition_to is enabled but jira_base_url, jira_email, or jira_api_token is missing";
+                if (inputs.jiraFailOnError) {
+                    core.setFailed(msg);
                 }
                 else {
-                    const prPayload = context.payload.pull_request;
-                    const pr = {
-                        number: prPayload.number,
-                        title: prPayload.title || "",
-                        body: prPayload.body || "",
-                        url: prPayload.html_url,
-                    };
-                    const prAction = context.payload.action || "opened";
-                    await (0, jira_1.postToJira)(keys, pr, jiraConfig, inputs.jiraCommentMode, prAction, inputs.jiraFailOnError, inputs.githubToken, inputs.allowedImageHosts);
+                    core.warning(msg);
                 }
             }
-            else if (!isPr) {
-                core.info("post_to_jira is enabled but event is not a pull_request — skipping");
+            else {
+                // Posting requires a pull_request event (it needs the PR body/number).
+                if (inputs.postToJira) {
+                    const { context } = github;
+                    const isPr = context.eventName === "pull_request" ||
+                        context.eventName === "pull_request_target";
+                    if (isPr && context.payload.pull_request) {
+                        const prPayload = context.payload.pull_request;
+                        const pr = {
+                            number: prPayload.number,
+                            title: prPayload.title || "",
+                            body: prPayload.body || "",
+                            url: prPayload.html_url,
+                        };
+                        const prAction = context.payload.action || "opened";
+                        await (0, jira_1.postToJira)(keys, pr, jiraConfig, inputs.jiraCommentMode, prAction, inputs.jiraFailOnError, inputs.githubToken, inputs.allowedImageHosts);
+                    }
+                    else if (!isPr) {
+                        core.info("post_to_jira is enabled but event is not a pull_request — skipping");
+                    }
+                }
+                // Transitions only need the issue keys + credentials — event-agnostic.
+                if (inputs.transitionTo) {
+                    await (0, jira_1.transitionIssues)(keys, inputs.transitionTo, jiraConfig, inputs.jiraFailOnError);
+                }
             }
         }
     }
@@ -30427,6 +30437,7 @@ exports.deduplicateFilenames = deduplicateFilenames;
 exports.downloadImage = downloadImage;
 exports.uploadAttachment = uploadAttachment;
 exports.postToJira = postToJira;
+exports.transitionIssues = transitionIssues;
 const core = __importStar(__nccwpck_require__(7484));
 const promises_1 = __nccwpck_require__(1553);
 const node_net_1 = __nccwpck_require__(7030);
@@ -30822,6 +30833,51 @@ async function postToJira(keys, pr, config, mode, prAction, failOnError, githubT
         }
         catch (error) {
             const msg = `Failed to post to ${key}: ${error instanceof Error ? error.message : String(error)}`;
+            if (failOnError) {
+                throw new Error(msg);
+            }
+            core.warning(msg);
+        }
+    }
+}
+async function transitionIssues(keys, targetStatus, config, failOnError) {
+    config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+    const wanted = targetStatus.toLowerCase();
+    for (const key of keys) {
+        try {
+            const url = `${config.baseUrl}/rest/api/2/issue/${encodeURIComponent(key)}/transitions`;
+            const listRes = await fetch(url, {
+                headers: {
+                    Authorization: authHeader(config),
+                    Accept: "application/json",
+                },
+            });
+            if (!listRes.ok) {
+                throw new Error(`Failed to fetch transitions for ${key}: ${listRes.status} ${listRes.statusText}`);
+            }
+            const { transitions } = (await listRes.json());
+            const match = transitions.find((t) => t.name.toLowerCase() === wanted);
+            if (!match) {
+                const available = transitions.map((t) => t.name).join(", ") || "none";
+                core.warning(`No "${targetStatus}" transition available for ${key} (available: ${available})`);
+                continue;
+            }
+            const postRes = await fetch(url, {
+                method: "POST",
+                headers: {
+                    Authorization: authHeader(config),
+                    "Content-Type": "application/json",
+                    Accept: "application/json",
+                },
+                body: JSON.stringify({ transition: { id: match.id } }),
+            });
+            if (!postRes.ok) {
+                throw new Error(`Failed to transition ${key} to ${targetStatus}: ${postRes.status} ${postRes.statusText}`);
+            }
+            core.info(`Transitioned ${key} → ${targetStatus}`);
+        }
+        catch (error) {
+            const msg = `Failed to transition ${key}: ${error instanceof Error ? error.message : String(error)}`;
             if (failOnError) {
                 throw new Error(msg);
             }

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,8 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 | `jira_email` | `""` | Jira account email for API authentication |
 | `jira_api_token` | `""` | Jira API token for authentication |
 | `jira_comment_mode` | `update` | Comment behavior: `update`, `new`, or `minimal` (see below) |
-| `jira_fail_on_error` | `false` | Fail the action if posting to Jira fails (default: warn only) |
+| `jira_fail_on_error` | `false` | Fail the action if posting to Jira or transitioning an issue fails (default: warn only) |
+| `transition_to` | `""` | Status name to transition matched issues to (e.g. `QA`, `Done`). Empty = no transition (see below) |
 | `github_token` | `""` | GitHub token for downloading GitHub-hosted images in PR bodies |
 | `allowed_image_hosts` | `""` | Comma-separated hostnames allowed for image downloads (empty = all non-private HTTPS hosts) |
 
@@ -112,6 +113,41 @@ When `post_to_jira` is enabled on `pull_request` events, the action posts the PR
 ```
 
 Images in the PR body are automatically downloaded and uploaded to Jira as attachments. The image references in the comment are updated to point to the uploaded files. Only HTTPS URLs are allowed, and private/loopback IPs are blocked. Use `allowed_image_hosts` to restrict downloads to specific domains.
+
+### Transition Issues
+
+Set `transition_to` to a status name and the action moves every matched issue to that status (using `jira_base_url`/`jira_email`/`jira_api_token`). The status is matched case-insensitively against the issue's available transitions. If no matching transition exists for an issue, the action logs a warning and continues — it does not fail (unless `jira_fail_on_error: true`). Transitions are event-agnostic: they run wherever issue keys are found, independent of `post_to_jira`.
+
+A common pattern is one job that moves issues to a review column when a PR opens, and another that moves them to Done when it merges:
+
+```yaml
+jobs:
+  to-qa:
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: procyon-creative/jira-action-man@v2
+        with:
+          projects: "PROJ"
+          from: "branch,title,commits,body"
+          transition_to: "QA"
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_email: ${{ secrets.JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+
+  to-done:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: procyon-creative/jira-action-man@v2
+        with:
+          projects: "PROJ"
+          from: "branch,title,commits,body"
+          transition_to: "Done"
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_email: ${{ secrets.JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+```
 
 ## Blocklist
 

--- a/docs/extract/functions/extractKeys.md
+++ b/docs/extract/functions/extractKeys.md
@@ -8,7 +8,7 @@
 
 > **extractKeys**(`text`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L34)
+Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L34)
 
 ## Parameters
 

--- a/docs/extract/functions/extractKeysFromTexts.md
+++ b/docs/extract/functions/extractKeysFromTexts.md
@@ -8,7 +8,7 @@
 
 > **extractKeysFromTexts**(`texts`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L51)
+Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L51)
 
 ## Parameters
 

--- a/docs/extract/functions/mergeAndSort.md
+++ b/docs/extract/functions/mergeAndSort.md
@@ -8,7 +8,7 @@
 
 > **mergeAndSort**(`keys`): `string`[]
 
-Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L63)
+Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L63)
 
 ## Parameters
 

--- a/docs/extract/variables/DEFAULT_BLOCKLIST.md
+++ b/docs/extract/variables/DEFAULT_BLOCKLIST.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_BLOCKLIST**: `string`[]
 
-Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L4)
+Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L4)

--- a/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
+++ b/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_ISSUE\_PATTERN**: `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"` = `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"`
 
-Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/extract.ts#L1)
+Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L1)

--- a/docs/jira/README.md
+++ b/docs/jira/README.md
@@ -15,4 +15,5 @@
 - [isSafeUrl](functions/isSafeUrl.md)
 - [postToJira](functions/postToJira.md)
 - [replaceImageUrls](functions/replaceImageUrls.md)
+- [transitionIssues](functions/transitionIssues.md)
 - [uploadAttachment](functions/uploadAttachment.md)

--- a/docs/jira/functions/deduplicateFilenames.md
+++ b/docs/jira/functions/deduplicateFilenames.md
@@ -8,7 +8,7 @@
 
 > **deduplicateFilenames**(`entries`): `Map`\<`string`, `string`\>
 
-Defined in: [jira.ts:177](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L177)
+Defined in: [jira.ts:177](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L177)
 
 ## Parameters
 

--- a/docs/jira/functions/downloadImage.md
+++ b/docs/jira/functions/downloadImage.md
@@ -8,7 +8,7 @@
 
 > **downloadImage**(`url`, `githubToken?`, `allowedHosts?`): `Promise`\<\{ `buffer`: `Buffer`; `contentType`: `string`; `filename`: `string`; \} \| `null`\>
 
-Defined in: [jira.ts:213](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L213)
+Defined in: [jira.ts:213](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L213)
 
 ## Parameters
 

--- a/docs/jira/functions/extractImageUrls.md
+++ b/docs/jira/functions/extractImageUrls.md
@@ -8,7 +8,7 @@
 
 > **extractImageUrls**(`markdown`): `ImageRef`[]
 
-Defined in: [jira.ts:38](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L38)
+Defined in: [jira.ts:38](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L38)
 
 ## Parameters
 

--- a/docs/jira/functions/isPrivateIp.md
+++ b/docs/jira/functions/isPrivateIp.md
@@ -8,7 +8,7 @@
 
 > **isPrivateIp**(`ip`): `boolean`
 
-Defined in: [jira.ts:101](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L101)
+Defined in: [jira.ts:101](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L101)
 
 ## Parameters
 

--- a/docs/jira/functions/isSafeUrl.md
+++ b/docs/jira/functions/isSafeUrl.md
@@ -8,7 +8,7 @@
 
 > **isSafeUrl**(`url`, `allowedHosts?`): `Promise`\<`boolean`\>
 
-Defined in: [jira.ts:111](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L111)
+Defined in: [jira.ts:111](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L111)
 
 ## Parameters
 

--- a/docs/jira/functions/postToJira.md
+++ b/docs/jira/functions/postToJira.md
@@ -8,7 +8,7 @@
 
 > **postToJira**(`keys`, `pr`, `config`, `mode`, `prAction`, `failOnError`, `githubToken?`, `allowedHosts?`): `Promise`\<`void`\>
 
-Defined in: [jira.ts:422](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L422)
+Defined in: [jira.ts:422](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L422)
 
 ## Parameters
 

--- a/docs/jira/functions/replaceImageUrls.md
+++ b/docs/jira/functions/replaceImageUrls.md
@@ -8,7 +8,7 @@
 
 > **replaceImageUrls**(`markdown`, `urlToFilename`): `string`
 
-Defined in: [jira.ts:54](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L54)
+Defined in: [jira.ts:54](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L54)
 
 ## Parameters
 

--- a/docs/jira/functions/transitionIssues.md
+++ b/docs/jira/functions/transitionIssues.md
@@ -1,0 +1,33 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / transitionIssues
+
+# Function: transitionIssues()
+
+> **transitionIssues**(`keys`, `targetStatus`, `config`, `failOnError`): `Promise`\<`void`\>
+
+Defined in: [jira.ts:537](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L537)
+
+## Parameters
+
+### keys
+
+`string`[]
+
+### targetStatus
+
+`string`
+
+### config
+
+[`JiraConfig`](../../types/interfaces/JiraConfig.md)
+
+### failOnError
+
+`boolean`
+
+## Returns
+
+`Promise`\<`void`\>

--- a/docs/jira/functions/uploadAttachment.md
+++ b/docs/jira/functions/uploadAttachment.md
@@ -8,7 +8,7 @@
 
 > **uploadAttachment**(`issueKey`, `filename`, `buffer`, `contentType`, `config`): `Promise`\<`boolean`\>
 
-Defined in: [jira.ts:290](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/jira.ts#L290)
+Defined in: [jira.ts:290](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L290)
 
 ## Parameters
 

--- a/docs/sources/functions/collectSourceTexts.md
+++ b/docs/sources/functions/collectSourceTexts.md
@@ -8,7 +8,7 @@
 
 > **collectSourceTexts**(`requestedSources`): [`SourceTexts`](../../types/interfaces/SourceTexts.md)
 
-Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/sources.ts#L5)
+Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/sources.ts#L5)
 
 ## Parameters
 

--- a/docs/sources/functions/sourceTextsToArray.md
+++ b/docs/sources/functions/sourceTextsToArray.md
@@ -8,7 +8,7 @@
 
 > **sourceTextsToArray**(`texts`): `string`[]
 
-Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/sources.ts#L93)
+Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/sources.ts#L93)
 
 ## Parameters
 

--- a/docs/types/interfaces/ActionInputs.md
+++ b/docs/types/interfaces/ActionInputs.md
@@ -6,7 +6,7 @@
 
 # Interface: ActionInputs
 
-Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L5)
+Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blo
 
 > `optional` **allowedImageHosts**: `string`[]
 
-Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L15)
+Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L16)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/bl
 
 > **blocklist**: `string`[]
 
-Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L9)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blo
 
 > **failOnMissing**: `boolean`
 
-Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L8)
+Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L8)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blo
 
 > **from**: [`Source`](../type-aliases/Source.md)[]
 
-Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L7)
+Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L7)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blo
 
 > `optional` **githubToken**: `string`
 
-Defined in: [types.ts:14](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L14)
+Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L15)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [types.ts:14](https://github.com/procyon-creative/jira-action-man/bl
 
 > **issuePattern**: `RegExp`
 
-Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L10)
+Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L10)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraCommentMode**: [`JiraCommentMode`](../type-aliases/JiraCommentMode.md)
 
-Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L12)
+Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L12)
 
 ***
 
@@ -70,7 +70,7 @@ Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraFailOnError**: `boolean`
 
-Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L13)
+Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L13)
 
 ***
 
@@ -78,7 +78,7 @@ Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/bl
 
 > **postToJira**: `boolean`
 
-Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L11)
+Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L11)
 
 ***
 
@@ -86,4 +86,12 @@ Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/bl
 
 > **projects**: `string`[]
 
-Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L6)
+Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L6)
+
+***
+
+### transitionTo?
+
+> `optional` **transitionTo**: `string`
+
+Defined in: [types.ts:14](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L14)

--- a/docs/types/interfaces/JiraConfig.md
+++ b/docs/types/interfaces/JiraConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: JiraConfig
 
-Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L18)
+Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L19)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/bl
 
 > **apiToken**: `string`
 
-Defined in: [types.ts:21](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L21)
+Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L22)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:21](https://github.com/procyon-creative/jira-action-man/bl
 
 > **baseUrl**: `string`
 
-Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L19)
+Defined in: [types.ts:20](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L20)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/bl
 
 > **email**: `string`
 
-Defined in: [types.ts:20](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L20)
+Defined in: [types.ts:21](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L21)

--- a/docs/types/interfaces/PrContext.md
+++ b/docs/types/interfaces/PrContext.md
@@ -6,7 +6,7 @@
 
 # Interface: PrContext
 
-Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L24)
+Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L25)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/bl
 
 > **body**: `string`
 
-Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L27)
+Defined in: [types.ts:28](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L28)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/bl
 
 > **number**: `number`
 
-Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L25)
+Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L26)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/bl
 
 > **title**: `string`
 
-Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L26)
+Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L27)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/bl
 
 > **url**: `string`
 
-Defined in: [types.ts:28](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L28)
+Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L29)

--- a/docs/types/interfaces/SourceTexts.md
+++ b/docs/types/interfaces/SourceTexts.md
@@ -6,7 +6,7 @@
 
 # Interface: SourceTexts
 
-Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L31)
+Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L32)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:31](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **body**: `string`
 
-Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L35)
+Defined in: [types.ts:36](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L36)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **branch**: `string`
 
-Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L32)
+Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L33)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **commits**: `string`[]
 
-Defined in: [types.ts:34](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L34)
+Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L35)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:34](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **title**: `string`
 
-Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L33)
+Defined in: [types.ts:34](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L34)

--- a/docs/types/type-aliases/JiraCommentMode.md
+++ b/docs/types/type-aliases/JiraCommentMode.md
@@ -8,4 +8,4 @@
 
 > **JiraCommentMode** = `"update"` \| `"new"` \| `"minimal"`
 
-Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L3)
+Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L3)

--- a/docs/types/type-aliases/Source.md
+++ b/docs/types/type-aliases/Source.md
@@ -8,4 +8,4 @@
 
 > **Source** = `"branch"` \| `"title"` \| `"commits"` \| `"body"`
 
-Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/95643d37286f81d86aaed55e1bfd9685e1cf4e37/src/types.ts#L1)
+Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-action-man",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-action-man",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-action-man",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "Extract Jira issue keys from GitHub events",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   extractKeysFromTexts,
 } from "./extract";
 import { collectSourceTexts, sourceTextsToArray } from "./sources";
-import { postToJira } from "./jira";
+import { postToJira, transitionIssues } from "./jira";
 
 function parseInputs(): ActionInputs {
   const projectsRaw = core.getInput("projects");
@@ -57,6 +57,8 @@ function parseInputs(): ActionInputs {
   ) as JiraCommentMode;
   const jiraFailOnError = core.getInput("jira_fail_on_error") === "true";
 
+  const transitionTo = core.getInput("transition_to").trim() || undefined;
+
   const githubToken = core.getInput("github_token") || undefined;
 
   const allowedHostsRaw = core.getInput("allowed_image_hosts");
@@ -76,6 +78,7 @@ function parseInputs(): ActionInputs {
     postToJira,
     jiraCommentMode,
     jiraFailOnError,
+    transitionTo,
     githubToken,
     allowedImageHosts,
   };
@@ -120,52 +123,68 @@ async function run(): Promise<void> {
       }
     }
 
-    if (inputs.postToJira && keys.length > 0) {
-      const { context } = github;
-      const isPr =
-        context.eventName === "pull_request" ||
-        context.eventName === "pull_request_target";
+    const needsJira =
+      (inputs.postToJira || !!inputs.transitionTo) && keys.length > 0;
 
-      if (isPr && context.payload.pull_request) {
-        const jiraConfig: JiraConfig = {
-          baseUrl: core.getInput("jira_base_url"),
-          email: core.getInput("jira_email"),
-          apiToken: core.getInput("jira_api_token"),
-        };
+    if (needsJira) {
+      const jiraConfig: JiraConfig = {
+        baseUrl: core.getInput("jira_base_url"),
+        email: core.getInput("jira_email"),
+        apiToken: core.getInput("jira_api_token"),
+      };
 
-        if (!jiraConfig.baseUrl || !jiraConfig.email || !jiraConfig.apiToken) {
-          const msg =
-            "post_to_jira is enabled but jira_base_url, jira_email, or jira_api_token is missing";
-          if (inputs.jiraFailOnError) {
-            core.setFailed(msg);
-          } else {
-            core.warning(msg);
-          }
+      if (!jiraConfig.baseUrl || !jiraConfig.email || !jiraConfig.apiToken) {
+        const msg =
+          "post_to_jira/transition_to is enabled but jira_base_url, jira_email, or jira_api_token is missing";
+        if (inputs.jiraFailOnError) {
+          core.setFailed(msg);
         } else {
-          const prPayload = context.payload.pull_request;
-          const pr: PrContext = {
-            number: prPayload.number as number,
-            title: (prPayload.title as string) || "",
-            body: (prPayload.body as string) || "",
-            url: prPayload.html_url as string,
-          };
+          core.warning(msg);
+        }
+      } else {
+        // Posting requires a pull_request event (it needs the PR body/number).
+        if (inputs.postToJira) {
+          const { context } = github;
+          const isPr =
+            context.eventName === "pull_request" ||
+            context.eventName === "pull_request_target";
 
-          const prAction = (context.payload.action as string) || "opened";
-          await postToJira(
+          if (isPr && context.payload.pull_request) {
+            const prPayload = context.payload.pull_request;
+            const pr: PrContext = {
+              number: prPayload.number as number,
+              title: (prPayload.title as string) || "",
+              body: (prPayload.body as string) || "",
+              url: prPayload.html_url as string,
+            };
+
+            const prAction = (context.payload.action as string) || "opened";
+            await postToJira(
+              keys,
+              pr,
+              jiraConfig,
+              inputs.jiraCommentMode,
+              prAction,
+              inputs.jiraFailOnError,
+              inputs.githubToken,
+              inputs.allowedImageHosts,
+            );
+          } else if (!isPr) {
+            core.info(
+              "post_to_jira is enabled but event is not a pull_request — skipping",
+            );
+          }
+        }
+
+        // Transitions only need the issue keys + credentials — event-agnostic.
+        if (inputs.transitionTo) {
+          await transitionIssues(
             keys,
-            pr,
+            inputs.transitionTo,
             jiraConfig,
-            inputs.jiraCommentMode,
-            prAction,
             inputs.jiraFailOnError,
-            inputs.githubToken,
-            inputs.allowedImageHosts,
           );
         }
-      } else if (!isPr) {
-        core.info(
-          "post_to_jira is enabled but event is not a pull_request — skipping",
-        );
       }
     }
   } catch (error) {

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -528,3 +528,72 @@ export async function postToJira(
     }
   }
 }
+
+interface JiraTransition {
+  id: string;
+  name: string;
+}
+
+export async function transitionIssues(
+  keys: string[],
+  targetStatus: string,
+  config: JiraConfig,
+  failOnError: boolean,
+): Promise<void> {
+  config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+  const wanted = targetStatus.toLowerCase();
+
+  for (const key of keys) {
+    try {
+      const url = `${config.baseUrl}/rest/api/2/issue/${encodeURIComponent(key)}/transitions`;
+
+      const listRes = await fetch(url, {
+        headers: {
+          Authorization: authHeader(config),
+          Accept: "application/json",
+        },
+      });
+      if (!listRes.ok) {
+        throw new Error(
+          `Failed to fetch transitions for ${key}: ${listRes.status} ${listRes.statusText}`,
+        );
+      }
+
+      const { transitions } = (await listRes.json()) as {
+        transitions: JiraTransition[];
+      };
+      const match = transitions.find((t) => t.name.toLowerCase() === wanted);
+
+      if (!match) {
+        const available = transitions.map((t) => t.name).join(", ") || "none";
+        core.warning(
+          `No "${targetStatus}" transition available for ${key} (available: ${available})`,
+        );
+        continue;
+      }
+
+      const postRes = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: authHeader(config),
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ transition: { id: match.id } }),
+      });
+      if (!postRes.ok) {
+        throw new Error(
+          `Failed to transition ${key} to ${targetStatus}: ${postRes.status} ${postRes.statusText}`,
+        );
+      }
+
+      core.info(`Transitioned ${key} → ${targetStatus}`);
+    } catch (error) {
+      const msg = `Failed to transition ${key}: ${error instanceof Error ? error.message : String(error)}`;
+      if (failOnError) {
+        throw new Error(msg);
+      }
+      core.warning(msg);
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface ActionInputs {
   postToJira: boolean;
   jiraCommentMode: JiraCommentMode;
   jiraFailOnError: boolean;
+  transitionTo?: string;
   githubToken?: string;
   allowedImageHosts?: string[];
 }

--- a/tests/jira.test.ts
+++ b/tests/jira.test.ts
@@ -1,5 +1,6 @@
 import {
   postToJira,
+  transitionIssues,
   extractImageUrls,
   replaceImageUrls,
   downloadImage,
@@ -836,5 +837,158 @@ describe("postToJira with images", () => {
     // Only 1 download (deduped) + 1 upload + 1 comment = 3
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(core.info).toHaveBeenCalledWith("Found 2 image(s) in PR body");
+  });
+});
+
+describe("transitionIssues", () => {
+  const origFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    core.info.mockClear();
+    core.warning.mockClear();
+  });
+
+  it("transitions an issue when a matching transition exists", async () => {
+    const fetchMock = mockFetch([
+      {
+        status: 200,
+        body: {
+          transitions: [
+            { id: "21", name: "In Progress" },
+            { id: "31", name: "QA" },
+          ],
+        },
+      },
+      { status: 204 },
+    ]);
+    global.fetch = fetchMock;
+
+    await transitionIssues(["PROJ-1"], "QA", config, false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const [listUrl, listOpts] = getCall(fetchMock, 0);
+    expect(listUrl).toBe(
+      "https://test.atlassian.net/rest/api/2/issue/PROJ-1/transitions",
+    );
+    expect(listOpts.method).toBeUndefined();
+
+    const [postUrl, postOpts] = getCall(fetchMock, 1);
+    expect(postUrl).toBe(
+      "https://test.atlassian.net/rest/api/2/issue/PROJ-1/transitions",
+    );
+    expect(postOpts.method).toBe("POST");
+    expect(JSON.parse(postOpts.body as string)).toEqual({
+      transition: { id: "31" },
+    });
+
+    expect(core.info).toHaveBeenCalledWith("Transitioned PROJ-1 → QA");
+  });
+
+  it("matches the target status case-insensitively", async () => {
+    const fetchMock = mockFetch([
+      { status: 200, body: { transitions: [{ id: "31", name: "QA" }] } },
+      { status: 204 },
+    ]);
+    global.fetch = fetchMock;
+
+    await transitionIssues(["PROJ-1"], "qa", config, false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(getCall(fetchMock, 1)[1].body as string)).toEqual({
+      transition: { id: "31" },
+    });
+  });
+
+  it("warns and skips the POST when no matching transition exists", async () => {
+    const fetchMock = mockFetch([
+      {
+        status: 200,
+        body: { transitions: [{ id: "21", name: "In Progress" }] },
+      },
+    ]);
+    global.fetch = fetchMock;
+
+    await transitionIssues(["PROJ-1"], "QA", config, false);
+
+    // Only the GET — no POST attempted.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('No "QA" transition available for PROJ-1'),
+    );
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("In Progress"),
+    );
+  });
+
+  it("transitions multiple issues", async () => {
+    const fetchMock = mockFetch([
+      { status: 200, body: { transitions: [{ id: "41", name: "Done" }] } },
+      { status: 204 },
+      { status: 200, body: { transitions: [{ id: "41", name: "Done" }] } },
+      { status: 204 },
+    ]);
+    global.fetch = fetchMock;
+
+    await transitionIssues(["PROJ-1", "PROJ-2"], "Done", config, false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(core.info).toHaveBeenCalledWith("Transitioned PROJ-1 → Done");
+    expect(core.info).toHaveBeenCalledWith("Transitioned PROJ-2 → Done");
+  });
+
+  it("warns on API error by default (failOnError=false)", async () => {
+    global.fetch = mockFetch([{ status: 500 }]);
+
+    await transitionIssues(["PROJ-1"], "QA", config, false);
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to transition PROJ-1"),
+    );
+  });
+
+  it("throws on API error when failOnError=true", async () => {
+    global.fetch = mockFetch([{ status: 500 }]);
+
+    await expect(
+      transitionIssues(["PROJ-1"], "QA", config, true),
+    ).rejects.toThrow("Failed to transition PROJ-1");
+  });
+
+  it("sends correct Basic auth header on the transitions request", async () => {
+    const fetchMock = mockFetch([
+      { status: 200, body: { transitions: [{ id: "31", name: "QA" }] } },
+      { status: 204 },
+    ]);
+    global.fetch = fetchMock;
+
+    await transitionIssues(["PROJ-1"], "QA", config, false);
+
+    const expectedAuth =
+      "Basic " + Buffer.from("user@example.com:test-token").toString("base64");
+    const [, getOpts] = getCall(fetchMock, 0);
+    expect((getOpts.headers as Record<string, string>).Authorization).toBe(
+      expectedAuth,
+    );
+  });
+
+  it("strips a trailing slash from the base URL", async () => {
+    const fetchMock = mockFetch([
+      { status: 200, body: { transitions: [{ id: "31", name: "QA" }] } },
+      { status: 204 },
+    ]);
+    global.fetch = fetchMock;
+
+    await transitionIssues(
+      ["PROJ-1"],
+      "QA",
+      { ...config, baseUrl: "https://test.atlassian.net/" },
+      false,
+    );
+
+    expect(getCall(fetchMock, 0)[0]).toBe(
+      "https://test.atlassian.net/rest/api/2/issue/PROJ-1/transitions",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds a `transition_to` input that moves every matched Jira issue to a named status. This lets consumers replace hand-rolled `curl` transition steps (which are fragile and error-prone) with a single, tested action call.

## Behavior

- `transition_to: "QA"` → each matched issue is moved to the **QA** status.
- Status is matched **case-insensitively** against the issue's available transitions.
- **No matching transition** → logs a warning and continues (does not fail). This covers boards where the target status isn't reachable yet.
- Obeys `jira_fail_on_error` (warn by default; fail when `true`).
- **Event-agnostic** and independent of `post_to_jira` — runs wherever issue keys are found. Uses the same `jira_base_url`/`jira_email`/`jira_api_token`.

## Implementation

- `src/jira.ts` — new exported `transitionIssues()` reusing `authHeader` and the trailing-slash strip; `GET` then `POST` to `/rest/api/2/issue/{key}/transitions`.
- `src/index.ts` — parse `transition_to`; Jira config is now read once and shared between posting and transitions.
- `action.yml`, `src/types.ts`, `README.md` updated; `dist/` rebuilt; bumped to `2.1.0`.

## Tests

8 new `transitionIssues` cases (match, case-insensitive, no-match warn, multi-issue, error warn/throw, auth header, trailing-slash). **107 tests pass**, typecheck + lint clean.

## Usage

```yaml
- uses: procyon-creative/jira-action-man@v2
  with:
    projects: "PROJ"
    from: "branch,title,commits,body"
    transition_to: "QA"
    jira_base_url: ${{ secrets.JIRA_BASE_URL }}
    jira_email: ${{ secrets.JIRA_EMAIL }}
    jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
```

After merge: cut release `v2.1.0` (the `update-main-version` workflow floats `v2` to it), then `procyon-plugin-boilerplate`'s `jira.yml` drops its inline `curl` for `transition_to`.