### PR TITLE
feat: create_issue_on_failure — open a Jira ticket on failed runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ INPUT_JIRA_COMMENT_MODE=update
 # Fail the action if posting to Jira fails (default: warn only)
 INPUT_JIRA_FAIL_ON_ERROR=false
 
+# Open a Jira ticket when a run fails (independent of issue keys; covers failing
+# dependabot PRs). Dedupes by label. Defaults: issue type "Bug", project = first
+# of INPUT_PROJECTS.
+INPUT_CREATE_ISSUE_ON_FAILURE=false
+INPUT_ISSUE_TYPE=Bug
+INPUT_ISSUE_PROJECT=
+
 # GitHub token used to download GitHub-hosted images embedded in PR bodies
 INPUT_GITHUB_TOKEN=
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 | `jira_comment_mode` | `update` | Comment behavior: `update`, `new`, or `minimal` (see below) |
 | `jira_fail_on_error` | `false` | Fail the action if posting to Jira or transitioning an issue fails (default: warn only) |
 | `transition_to` | `""` | Status name to transition matched issues to (e.g. `QA`, `Done`). Empty = no transition (see below) |
+| `create_issue_on_failure` | `false` | Open a Jira ticket when a run fails (independent of issue keys — covers failing dependabot PRs). See below |
+| `issue_type` | `Bug` | Issue type for the ticket created by `create_issue_on_failure` (must exist in the project) |
+| `issue_project` | `""` | Project key for the failure ticket. Defaults to the first entry of `projects` |
 | `github_token` | `""` | GitHub token for downloading GitHub-hosted images in PR bodies |
 | `allowed_image_hosts` | `""` | Comma-separated hostnames allowed for image downloads (empty = all non-private HTTPS hosts) |
 
@@ -45,6 +48,7 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 | `keys` | JSON array of unique sorted keys, e.g. `["PROJ-123","PROJ-456"]` |
 | `key` | First key found (convenience) |
 | `found` | `"true"` or `"false"` |
+| `created_issue` | Key of the ticket created (or reused) by `create_issue_on_failure`, or empty |
 
 Keys are sorted alphabetically by project prefix, then numerically by issue number (`PROJ-2` before `PROJ-10`).
 
@@ -113,6 +117,37 @@ Images in the PR body are automatically downloaded and uploaded to Jira as attac
 ### Transition Issues
 
 Set `transition_to` to a status name and the action moves every matched issue to that status (using `jira_base_url`/`jira_email`/`jira_api_token`). The status is matched case-insensitively against the issue's available transitions. If no matching transition exists for an issue, the action logs a warning and continues — it does not fail (unless `jira_fail_on_error: true`). Transitions are event-agnostic: they run wherever issue keys are found, independent of `post_to_jira`.
+
+### Open a Ticket When CI Fails
+
+`create_issue_on_failure` files a Jira ticket when a run fails — even when the PR carries **no** issue key (e.g. a failing **dependabot** PR). Tickets are **deduplicated by label**, so repeated failures of the same PR/branch reuse one open ticket instead of spamming a new one each run.
+
+Trigger it from a `workflow_run` on your CI workflow — the action reads the run's conclusion and only files a ticket on `failure`:
+
+```yaml
+name: CI Failures → Jira
+on:
+  workflow_run:
+    workflows: ["CI"] # the name: of your CI workflow
+    types: [completed]
+
+jobs:
+  file-ticket:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: procyon-creative/jira-action-man@v2
+        with:
+          create_issue_on_failure: true
+          issue_project: "PROJ" # or rely on `projects`
+          issue_type: "Bug"
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_email: ${{ secrets.JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+```
+
+Alternatively, call it from an `if: failure()` job in the same workflow as your build — it then files a ticket for the current PR/branch.
+
+The created ticket carries two labels: `ci-failure` and a per-target dedup label (e.g. `cifail-org-repo-pr-6`). Move that ticket to a Done status (or close it) and the next failure opens a fresh one. The created key is exposed as the `created_issue` output.
 
 A common pattern is one job that moves issues to a review column when a PR opens, and another that moves them to Done when it merges:
 

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,18 @@ inputs:
     description: "Status name to transition matched issues to (e.g. 'QA', 'Done'). Empty = no transition. Uses jira_base_url/email/token; obeys jira_fail_on_error (warn by default)."
     required: false
     default: ""
+  create_issue_on_failure:
+    description: "Open a Jira ticket when a run fails (independent of issue keys — covers failing dependabot PRs). Run this from a workflow_run on your CI workflow, or an `if: failure()` job. Dedupes by label so a given PR/branch reuses one open ticket. Uses jira_base_url/email/token; obeys jira_fail_on_error."
+    required: false
+    default: "false"
+  issue_type:
+    description: "Issue type for the ticket created by create_issue_on_failure (must exist in the project)."
+    required: false
+    default: "Bug"
+  issue_project:
+    description: "Project key for the ticket created by create_issue_on_failure. Defaults to the first entry of `projects`."
+    required: false
+    default: ""
   github_token:
     description: "GitHub token used to authorize image downloads from GitHub-hosted URLs in PR bodies. Usually secrets.GITHUB_TOKEN."
     required: false
@@ -67,6 +79,8 @@ outputs:
     description: "First Jira issue key found (convenience)"
   found:
     description: '"true" if any keys were found, "false" otherwise'
+  created_issue:
+    description: "Key of the Jira ticket created (or reused) by create_issue_on_failure, or empty"
 
 runs:
   using: "node24"

--- a/dist/index.js
+++ b/dist/index.js
@@ -30202,6 +30202,180 @@ function mergeAndSort(keys) {
 
 /***/ }),
 
+/***/ 1633:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveFailureContext = resolveFailureContext;
+exports.buildFailureIssue = buildFailureIssue;
+exports.createFailureIssue = createFailureIssue;
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const jira_1 = __nccwpck_require__(7647);
+/**
+ * Work out what failed, from the GitHub event context.
+ *
+ * - `workflow_run`: the natural "CI finished" signal. We only return a context
+ *   when the run actually FAILED (conclusion === "failure"); otherwise null so
+ *   the caller does nothing. PR info comes from `workflow_run.pull_requests`.
+ * - any other event (e.g. `pull_request`): we assume the workflow gated this
+ *   step on failure itself (`if: failure()`), so we build the context from the
+ *   PR payload (or the ref for pushes).
+ *
+ * Returns null when there's nothing to file a ticket for.
+ */
+function resolveFailureContext() {
+    const { context } = github;
+    const repo = context.payload.repository?.full_name ||
+        (context.payload.repository
+            ? `${context.payload.repository.owner?.login}/${context.payload.repository.name}`
+            : undefined);
+    if (context.eventName === "workflow_run") {
+        const wr = context.payload.workflow_run;
+        if (!wr)
+            return null;
+        // Only act on genuine failures.
+        if (wr.conclusion !== "failure")
+            return null;
+        const prNumber = wr.pull_requests?.[0]?.number;
+        const branch = wr.head_branch;
+        const url = prNumber && repo
+            ? `https://github.com/${repo}/pull/${prNumber}`
+            : undefined;
+        return {
+            title: prNumber ? `PR #${prNumber}` : `branch ${branch ?? "?"}`,
+            repo,
+            prNumber,
+            branch,
+            url,
+            runUrl: wr.html_url,
+        };
+    }
+    const pr = context.payload.pull_request;
+    if (pr) {
+        return {
+            title: pr.title || `PR #${pr.number}`,
+            repo,
+            prNumber: pr.number,
+            branch: pr.head?.ref,
+            url: pr.html_url,
+        };
+    }
+    // Fallback: a push/other event the workflow gated on failure.
+    const branch = context.ref?.replace(/^refs\/heads\//, "");
+    return { title: branch ? `branch ${branch}` : "build", repo, branch };
+}
+function slug(s) {
+    return s
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 40);
+}
+/**
+ * Build the summary, description and labels for a CI-failure ticket. Pure — no
+ * network. The second label is a deterministic dedup key so repeated failures of
+ * the same PR/branch reuse a single open ticket.
+ */
+function buildFailureIssue(ctx) {
+    const idLabel = ctx.prNumber
+        ? `PR #${ctx.prNumber}`
+        : ctx.branch
+            ? `branch ${ctx.branch}`
+            : "build";
+    const summary = `CI failed: ${idLabel}${ctx.prNumber && ctx.branch ? ` (${ctx.branch})` : ""}`.slice(0, 250);
+    const idSlug = ctx.prNumber
+        ? `pr-${ctx.prNumber}`
+        : slug(ctx.branch || "build");
+    const repoSlug = ctx.repo ? slug(ctx.repo) : "repo";
+    const dedupeLabel = `cifail-${repoSlug}-${idSlug}`.slice(0, 50);
+    const labels = ["ci-failure", dedupeLabel];
+    const lines = [
+        "A CI run failed. This ticket was opened automatically by jira-action-man.",
+        "",
+    ];
+    if (ctx.url)
+        lines.push(`* PR: ${ctx.url}`);
+    if (ctx.branch)
+        lines.push(`* Branch: {{${ctx.branch}}}`);
+    if (ctx.runUrl)
+        lines.push(`* Failed run: ${ctx.runUrl}`);
+    if (ctx.repo)
+        lines.push(`* Repo: ${ctx.repo}`);
+    return { summary, description: lines.join("\n"), labels, dedupeLabel };
+}
+/**
+ * Create a CI-failure ticket, unless an open one already exists for the same
+ * PR/branch (matched by the dedup label). Obeys failOnError (warn by default).
+ * Returns the issue key (existing or new), or null on a swallowed error.
+ */
+async function createFailureIssue(ctx, config, projectKey, issueType, failOnError) {
+    const { summary, description, labels, dedupeLabel } = buildFailureIssue(ctx);
+    try {
+        const jql = `project = "${projectKey}" AND statusCategory != Done AND labels = "${dedupeLabel}"`;
+        const existing = await (0, jira_1.searchIssue)(config, jql);
+        if (existing) {
+            core.info(`Open CI-failure ticket already exists for ${dedupeLabel}: ${existing} — not creating a duplicate`);
+            return existing;
+        }
+        const key = await (0, jira_1.createIssue)(config, {
+            projectKey,
+            issueType,
+            summary,
+            description,
+            labels,
+        });
+        core.info(`Created CI-failure ticket ${key} (${projectKey})`);
+        return key;
+    }
+    catch (error) {
+        const msg = `Failed to create CI-failure issue: ${error instanceof Error ? error.message : String(error)}`;
+        if (failOnError) {
+            throw new Error(msg);
+        }
+        core.warning(msg);
+        return null;
+    }
+}
+
+
+/***/ }),
+
 /***/ 9407:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -30246,6 +30420,7 @@ const github = __importStar(__nccwpck_require__(3228));
 const extract_1 = __nccwpck_require__(6542);
 const sources_1 = __nccwpck_require__(8578);
 const jira_1 = __nccwpck_require__(7647);
+const failure_1 = __nccwpck_require__(1633);
 function parseInputs() {
     const projectsRaw = core.getInput("projects");
     const projects = projectsRaw
@@ -30283,6 +30458,9 @@ function parseInputs() {
         : "update");
     const jiraFailOnError = core.getInput("jira_fail_on_error") === "true";
     const transitionTo = core.getInput("transition_to").trim() || undefined;
+    const createIssueOnFailure = core.getInput("create_issue_on_failure") === "true";
+    const issueType = core.getInput("issue_type").trim() || "Bug";
+    const issueProject = core.getInput("issue_project").trim().toUpperCase() || undefined;
     const githubToken = core.getInput("github_token") || undefined;
     const allowedHostsRaw = core.getInput("allowed_image_hosts");
     const allowedImageHosts = allowedHostsRaw
@@ -30301,6 +30479,9 @@ function parseInputs() {
         jiraCommentMode,
         jiraFailOnError,
         transitionTo,
+        createIssueOnFailure,
+        issueType,
+        issueProject,
         githubToken,
         allowedImageHosts,
     };
@@ -30377,6 +30558,42 @@ async function run() {
                 }
             }
         }
+        // Open a Jira ticket when a run has failed. Independent of issue keys —
+        // a failing dependabot PR carries no key, which is exactly the case this
+        // covers. Gated by create_issue_on_failure; the workflow decides when to
+        // run this (a workflow_run on the CI workflow, or an `if: failure()` job).
+        if (inputs.createIssueOnFailure) {
+            const jiraConfig = {
+                baseUrl: core.getInput("jira_base_url"),
+                email: core.getInput("jira_email"),
+                apiToken: core.getInput("jira_api_token"),
+            };
+            const projectKey = inputs.issueProject || inputs.projects[0];
+            if (!jiraConfig.baseUrl || !jiraConfig.email || !jiraConfig.apiToken) {
+                const msg = "create_issue_on_failure is enabled but jira_base_url, jira_email, or jira_api_token is missing";
+                if (inputs.jiraFailOnError)
+                    core.setFailed(msg);
+                else
+                    core.warning(msg);
+            }
+            else if (!projectKey) {
+                const msg = "create_issue_on_failure is enabled but no target project (set issue_project, or projects)";
+                if (inputs.jiraFailOnError)
+                    core.setFailed(msg);
+                else
+                    core.warning(msg);
+            }
+            else {
+                const failureCtx = (0, failure_1.resolveFailureContext)();
+                if (!failureCtx) {
+                    core.info("create_issue_on_failure: no failed run detected for this event — skipping");
+                }
+                else {
+                    const created = await (0, failure_1.createFailureIssue)(failureCtx, jiraConfig, projectKey, inputs.issueType, inputs.jiraFailOnError);
+                    core.setOutput("created_issue", created || "");
+                }
+            }
+        }
     }
     catch (error) {
         core.setFailed(error instanceof Error ? error.message : String(error));
@@ -30438,6 +30655,8 @@ exports.downloadImage = downloadImage;
 exports.uploadAttachment = uploadAttachment;
 exports.postToJira = postToJira;
 exports.transitionIssues = transitionIssues;
+exports.createIssue = createIssue;
+exports.searchIssue = searchIssue;
 const core = __importStar(__nccwpck_require__(7484));
 const promises_1 = __nccwpck_require__(1553);
 const node_net_1 = __nccwpck_require__(7030);
@@ -30884,6 +31103,55 @@ async function transitionIssues(keys, targetStatus, config, failOnError) {
             core.warning(msg);
         }
     }
+}
+async function createIssue(config, opts) {
+    config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+    const url = `${config.baseUrl}/rest/api/2/issue`;
+    const res = await fetch(url, {
+        method: "POST",
+        headers: {
+            Authorization: authHeader(config),
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({
+            fields: {
+                project: { key: opts.projectKey },
+                issuetype: { name: opts.issueType },
+                summary: opts.summary,
+                description: opts.description,
+                ...(opts.labels && opts.labels.length > 0
+                    ? { labels: opts.labels }
+                    : {}),
+            },
+        }),
+    });
+    if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`Failed to create issue in ${opts.projectKey}: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ""}`);
+    }
+    const data = (await res.json());
+    return data.key;
+}
+// Uses the enhanced JQL search endpoint (the legacy /rest/api/2/search is being
+// sunset by Atlassian). Returns the first matching issue key, or null.
+async function searchIssue(config, jql) {
+    config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+    const url = `${config.baseUrl}/rest/api/3/search/jql`;
+    const res = await fetch(url, {
+        method: "POST",
+        headers: {
+            Authorization: authHeader(config),
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({ jql, maxResults: 1, fields: ["key"] }),
+    });
+    if (!res.ok) {
+        throw new Error(`Failed to search issues: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json());
+    return data.issues?.[0]?.key ?? null;
 }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,9 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 | `jira_comment_mode` | `update` | Comment behavior: `update`, `new`, or `minimal` (see below) |
 | `jira_fail_on_error` | `false` | Fail the action if posting to Jira or transitioning an issue fails (default: warn only) |
 | `transition_to` | `""` | Status name to transition matched issues to (e.g. `QA`, `Done`). Empty = no transition (see below) |
+| `create_issue_on_failure` | `false` | Open a Jira ticket when a run fails (independent of issue keys — covers failing dependabot PRs). See below |
+| `issue_type` | `Bug` | Issue type for the ticket created by `create_issue_on_failure` (must exist in the project) |
+| `issue_project` | `""` | Project key for the failure ticket. Defaults to the first entry of `projects` |
 | `github_token` | `""` | GitHub token for downloading GitHub-hosted images in PR bodies |
 | `allowed_image_hosts` | `""` | Comma-separated hostnames allowed for image downloads (empty = all non-private HTTPS hosts) |
 
@@ -49,6 +52,7 @@ A GitHub Action that extracts Jira issue keys from GitHub events and posts PR co
 | `keys` | JSON array of unique sorted keys, e.g. `["PROJ-123","PROJ-456"]` |
 | `key` | First key found (convenience) |
 | `found` | `"true"` or `"false"` |
+| `created_issue` | Key of the ticket created (or reused) by `create_issue_on_failure`, or empty |
 
 Keys are sorted alphabetically by project prefix, then numerically by issue number (`PROJ-2` before `PROJ-10`).
 
@@ -117,6 +121,37 @@ Images in the PR body are automatically downloaded and uploaded to Jira as attac
 ### Transition Issues
 
 Set `transition_to` to a status name and the action moves every matched issue to that status (using `jira_base_url`/`jira_email`/`jira_api_token`). The status is matched case-insensitively against the issue's available transitions. If no matching transition exists for an issue, the action logs a warning and continues — it does not fail (unless `jira_fail_on_error: true`). Transitions are event-agnostic: they run wherever issue keys are found, independent of `post_to_jira`.
+
+### Open a Ticket When CI Fails
+
+`create_issue_on_failure` files a Jira ticket when a run fails — even when the PR carries **no** issue key (e.g. a failing **dependabot** PR). Tickets are **deduplicated by label**, so repeated failures of the same PR/branch reuse one open ticket instead of spamming a new one each run.
+
+Trigger it from a `workflow_run` on your CI workflow — the action reads the run's conclusion and only files a ticket on `failure`:
+
+```yaml
+name: CI Failures → Jira
+on:
+  workflow_run:
+    workflows: ["CI"] # the name: of your CI workflow
+    types: [completed]
+
+jobs:
+  file-ticket:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: procyon-creative/jira-action-man@v2
+        with:
+          create_issue_on_failure: true
+          issue_project: "PROJ" # or rely on `projects`
+          issue_type: "Bug"
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_email: ${{ secrets.JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+```
+
+Alternatively, call it from an `if: failure()` job in the same workflow as your build — it then files a ticket for the current PR/branch.
+
+The created ticket carries two labels: `ci-failure` and a per-target dedup label (e.g. `cifail-org-repo-pr-6`). Move that ticket to a Done status (or close it) and the next failure opens a fresh one. The created key is exposed as the `created_issue` output.
 
 A common pattern is one job that moves issues to a review column when a PR opens, and another that moves them to Done when it merges:
 

--- a/docs/extract/functions/extractKeys.md
+++ b/docs/extract/functions/extractKeys.md
@@ -8,7 +8,7 @@
 
 > **extractKeys**(`text`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L34)
+Defined in: [extract.ts:34](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/extract.ts#L34)
 
 ## Parameters
 

--- a/docs/extract/functions/extractKeysFromTexts.md
+++ b/docs/extract/functions/extractKeysFromTexts.md
@@ -8,7 +8,7 @@
 
 > **extractKeysFromTexts**(`texts`, `projects`, `blocklist`, `pattern`): `string`[]
 
-Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L51)
+Defined in: [extract.ts:51](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/extract.ts#L51)
 
 ## Parameters
 

--- a/docs/extract/functions/mergeAndSort.md
+++ b/docs/extract/functions/mergeAndSort.md
@@ -8,7 +8,7 @@
 
 > **mergeAndSort**(`keys`): `string`[]
 
-Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L63)
+Defined in: [extract.ts:63](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/extract.ts#L63)
 
 ## Parameters
 

--- a/docs/extract/variables/DEFAULT_BLOCKLIST.md
+++ b/docs/extract/variables/DEFAULT_BLOCKLIST.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_BLOCKLIST**: `string`[]
 
-Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L4)
+Defined in: [extract.ts:4](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/extract.ts#L4)

--- a/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
+++ b/docs/extract/variables/DEFAULT_ISSUE_PATTERN.md
@@ -8,4 +8,4 @@
 
 > `const` **DEFAULT\_ISSUE\_PATTERN**: `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"` = `"(?<![A-Z0-9])([A-Z][A-Z0-9]{1,9}-[0-9]{1,6})(?![A-Z0-9])"`
 
-Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/extract.ts#L1)
+Defined in: [extract.ts:1](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/extract.ts#L1)

--- a/docs/jira/README.md
+++ b/docs/jira/README.md
@@ -6,8 +6,13 @@
 
 # jira
 
+## Interfaces
+
+- [CreateIssueOptions](interfaces/CreateIssueOptions.md)
+
 ## Functions
 
+- [createIssue](functions/createIssue.md)
 - [deduplicateFilenames](functions/deduplicateFilenames.md)
 - [downloadImage](functions/downloadImage.md)
 - [extractImageUrls](functions/extractImageUrls.md)
@@ -15,5 +20,6 @@
 - [isSafeUrl](functions/isSafeUrl.md)
 - [postToJira](functions/postToJira.md)
 - [replaceImageUrls](functions/replaceImageUrls.md)
+- [searchIssue](functions/searchIssue.md)
 - [transitionIssues](functions/transitionIssues.md)
 - [uploadAttachment](functions/uploadAttachment.md)

--- a/docs/jira/functions/createIssue.md
+++ b/docs/jira/functions/createIssue.md
@@ -1,0 +1,25 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / createIssue
+
+# Function: createIssue()
+
+> **createIssue**(`config`, `opts`): `Promise`\<`string`\>
+
+Defined in: [jira.ts:609](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L609)
+
+## Parameters
+
+### config
+
+[`JiraConfig`](../../types/interfaces/JiraConfig.md)
+
+### opts
+
+[`CreateIssueOptions`](../interfaces/CreateIssueOptions.md)
+
+## Returns
+
+`Promise`\<`string`\>

--- a/docs/jira/functions/deduplicateFilenames.md
+++ b/docs/jira/functions/deduplicateFilenames.md
@@ -8,7 +8,7 @@
 
 > **deduplicateFilenames**(`entries`): `Map`\<`string`, `string`\>
 
-Defined in: [jira.ts:177](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L177)
+Defined in: [jira.ts:177](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L177)
 
 ## Parameters
 

--- a/docs/jira/functions/downloadImage.md
+++ b/docs/jira/functions/downloadImage.md
@@ -8,7 +8,7 @@
 
 > **downloadImage**(`url`, `githubToken?`, `allowedHosts?`): `Promise`\<\{ `buffer`: `Buffer`; `contentType`: `string`; `filename`: `string`; \} \| `null`\>
 
-Defined in: [jira.ts:213](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L213)
+Defined in: [jira.ts:213](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L213)
 
 ## Parameters
 

--- a/docs/jira/functions/extractImageUrls.md
+++ b/docs/jira/functions/extractImageUrls.md
@@ -8,7 +8,7 @@
 
 > **extractImageUrls**(`markdown`): `ImageRef`[]
 
-Defined in: [jira.ts:38](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L38)
+Defined in: [jira.ts:38](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L38)
 
 ## Parameters
 

--- a/docs/jira/functions/isPrivateIp.md
+++ b/docs/jira/functions/isPrivateIp.md
@@ -8,7 +8,7 @@
 
 > **isPrivateIp**(`ip`): `boolean`
 
-Defined in: [jira.ts:101](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L101)
+Defined in: [jira.ts:101](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L101)
 
 ## Parameters
 

--- a/docs/jira/functions/isSafeUrl.md
+++ b/docs/jira/functions/isSafeUrl.md
@@ -8,7 +8,7 @@
 
 > **isSafeUrl**(`url`, `allowedHosts?`): `Promise`\<`boolean`\>
 
-Defined in: [jira.ts:111](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L111)
+Defined in: [jira.ts:111](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L111)
 
 ## Parameters
 

--- a/docs/jira/functions/postToJira.md
+++ b/docs/jira/functions/postToJira.md
@@ -8,7 +8,7 @@
 
 > **postToJira**(`keys`, `pr`, `config`, `mode`, `prAction`, `failOnError`, `githubToken?`, `allowedHosts?`): `Promise`\<`void`\>
 
-Defined in: [jira.ts:422](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L422)
+Defined in: [jira.ts:422](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L422)
 
 ## Parameters
 

--- a/docs/jira/functions/replaceImageUrls.md
+++ b/docs/jira/functions/replaceImageUrls.md
@@ -8,7 +8,7 @@
 
 > **replaceImageUrls**(`markdown`, `urlToFilename`): `string`
 
-Defined in: [jira.ts:54](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L54)
+Defined in: [jira.ts:54](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L54)
 
 ## Parameters
 

--- a/docs/jira/functions/searchIssue.md
+++ b/docs/jira/functions/searchIssue.md
@@ -1,0 +1,25 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / searchIssue
+
+# Function: searchIssue()
+
+> **searchIssue**(`config`, `jql`): `Promise`\<`string` \| `null`\>
+
+Defined in: [jira.ts:646](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L646)
+
+## Parameters
+
+### config
+
+[`JiraConfig`](../../types/interfaces/JiraConfig.md)
+
+### jql
+
+`string`
+
+## Returns
+
+`Promise`\<`string` \| `null`\>

--- a/docs/jira/functions/transitionIssues.md
+++ b/docs/jira/functions/transitionIssues.md
@@ -8,7 +8,7 @@
 
 > **transitionIssues**(`keys`, `targetStatus`, `config`, `failOnError`): `Promise`\<`void`\>
 
-Defined in: [jira.ts:537](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L537)
+Defined in: [jira.ts:537](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L537)
 
 ## Parameters
 

--- a/docs/jira/functions/uploadAttachment.md
+++ b/docs/jira/functions/uploadAttachment.md
@@ -8,7 +8,7 @@
 
 > **uploadAttachment**(`issueKey`, `filename`, `buffer`, `contentType`, `config`): `Promise`\<`boolean`\>
 
-Defined in: [jira.ts:290](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/jira.ts#L290)
+Defined in: [jira.ts:290](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L290)
 
 ## Parameters
 

--- a/docs/jira/interfaces/CreateIssueOptions.md
+++ b/docs/jira/interfaces/CreateIssueOptions.md
@@ -1,0 +1,49 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [jira](../README.md) / CreateIssueOptions
+
+# Interface: CreateIssueOptions
+
+Defined in: [jira.ts:601](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L601)
+
+## Properties
+
+### description
+
+> **description**: `string`
+
+Defined in: [jira.ts:605](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L605)
+
+***
+
+### issueType
+
+> **issueType**: `string`
+
+Defined in: [jira.ts:603](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L603)
+
+***
+
+### labels?
+
+> `optional` **labels**: `string`[]
+
+Defined in: [jira.ts:606](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L606)
+
+***
+
+### projectKey
+
+> **projectKey**: `string`
+
+Defined in: [jira.ts:602](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L602)
+
+***
+
+### summary
+
+> **summary**: `string`
+
+Defined in: [jira.ts:604](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/jira.ts#L604)

--- a/docs/sources/functions/collectSourceTexts.md
+++ b/docs/sources/functions/collectSourceTexts.md
@@ -8,7 +8,7 @@
 
 > **collectSourceTexts**(`requestedSources`): [`SourceTexts`](../../types/interfaces/SourceTexts.md)
 
-Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/sources.ts#L5)
+Defined in: [sources.ts:5](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/sources.ts#L5)
 
 ## Parameters
 

--- a/docs/sources/functions/sourceTextsToArray.md
+++ b/docs/sources/functions/sourceTextsToArray.md
@@ -8,7 +8,7 @@
 
 > **sourceTextsToArray**(`texts`): `string`[]
 
-Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/sources.ts#L93)
+Defined in: [sources.ts:93](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/sources.ts#L93)
 
 ## Parameters
 

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -9,6 +9,7 @@
 ## Interfaces
 
 - [ActionInputs](interfaces/ActionInputs.md)
+- [FailureContext](interfaces/FailureContext.md)
 - [JiraConfig](interfaces/JiraConfig.md)
 - [PrContext](interfaces/PrContext.md)
 - [SourceTexts](interfaces/SourceTexts.md)

--- a/docs/types/interfaces/ActionInputs.md
+++ b/docs/types/interfaces/ActionInputs.md
@@ -6,7 +6,7 @@
 
 # Interface: ActionInputs
 
-Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L5)
+Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:5](https://github.com/procyon-creative/jira-action-man/blo
 
 > `optional` **allowedImageHosts**: `string`[]
 
-Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L16)
+Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L19)
 
 ***
 
@@ -22,7 +22,15 @@ Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/bl
 
 > **blocklist**: `string`[]
 
-Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L9)
+
+***
+
+### createIssueOnFailure
+
+> **createIssueOnFailure**: `boolean`
+
+Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L15)
 
 ***
 
@@ -30,7 +38,7 @@ Defined in: [types.ts:9](https://github.com/procyon-creative/jira-action-man/blo
 
 > **failOnMissing**: `boolean`
 
-Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L8)
+Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L8)
 
 ***
 
@@ -38,7 +46,7 @@ Defined in: [types.ts:8](https://github.com/procyon-creative/jira-action-man/blo
 
 > **from**: [`Source`](../type-aliases/Source.md)[]
 
-Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L7)
+Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L7)
 
 ***
 
@@ -46,7 +54,7 @@ Defined in: [types.ts:7](https://github.com/procyon-creative/jira-action-man/blo
 
 > `optional` **githubToken**: `string`
 
-Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L15)
+Defined in: [types.ts:18](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L18)
 
 ***
 
@@ -54,7 +62,23 @@ Defined in: [types.ts:15](https://github.com/procyon-creative/jira-action-man/bl
 
 > **issuePattern**: `RegExp`
 
-Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L10)
+Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L10)
+
+***
+
+### issueProject?
+
+> `optional` **issueProject**: `string`
+
+Defined in: [types.ts:17](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L17)
+
+***
+
+### issueType
+
+> **issueType**: `string`
+
+Defined in: [types.ts:16](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L16)
 
 ***
 
@@ -62,7 +86,7 @@ Defined in: [types.ts:10](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraCommentMode**: [`JiraCommentMode`](../type-aliases/JiraCommentMode.md)
 
-Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L12)
+Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L12)
 
 ***
 
@@ -70,7 +94,7 @@ Defined in: [types.ts:12](https://github.com/procyon-creative/jira-action-man/bl
 
 > **jiraFailOnError**: `boolean`
 
-Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L13)
+Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L13)
 
 ***
 
@@ -78,7 +102,7 @@ Defined in: [types.ts:13](https://github.com/procyon-creative/jira-action-man/bl
 
 > **postToJira**: `boolean`
 
-Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L11)
+Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L11)
 
 ***
 
@@ -86,7 +110,7 @@ Defined in: [types.ts:11](https://github.com/procyon-creative/jira-action-man/bl
 
 > **projects**: `string`[]
 
-Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L6)
+Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L6)
 
 ***
 
@@ -94,4 +118,4 @@ Defined in: [types.ts:6](https://github.com/procyon-creative/jira-action-man/blo
 
 > `optional` **transitionTo**: `string`
 
-Defined in: [types.ts:14](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L14)
+Defined in: [types.ts:14](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L14)

--- a/docs/types/interfaces/FailureContext.md
+++ b/docs/types/interfaces/FailureContext.md
@@ -1,0 +1,65 @@
+[**jira-action-man**](../../README.md)
+
+***
+
+[jira-action-man](../../modules.md) / [types](../README.md) / FailureContext
+
+# Interface: FailureContext
+
+Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L22)
+
+## Properties
+
+### branch?
+
+> `optional` **branch**: `string`
+
+Defined in: [types.ts:28](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L28)
+
+***
+
+### prNumber?
+
+> `optional` **prNumber**: `number`
+
+Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L27)
+
+***
+
+### repo?
+
+> `optional` **repo**: `string`
+
+Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L26)
+
+owner/repo
+
+***
+
+### runUrl?
+
+> `optional` **runUrl**: `string`
+
+Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L32)
+
+URL of the failed workflow run, when available.
+
+***
+
+### title
+
+> **title**: `string`
+
+Defined in: [types.ts:24](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L24)
+
+Human label for the failing thing, e.g. "PR #6" or "branch main".
+
+***
+
+### url?
+
+> `optional` **url**: `string`
+
+Defined in: [types.ts:30](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L30)
+
+PR html_url, when a PR is associated.

--- a/docs/types/interfaces/JiraConfig.md
+++ b/docs/types/interfaces/JiraConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: JiraConfig
 
-Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L19)
+Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L35)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:19](https://github.com/procyon-creative/jira-action-man/bl
 
 > **apiToken**: `string`
 
-Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L22)
+Defined in: [types.ts:38](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L38)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:22](https://github.com/procyon-creative/jira-action-man/bl
 
 > **baseUrl**: `string`
 
-Defined in: [types.ts:20](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L20)
+Defined in: [types.ts:36](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L36)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [types.ts:20](https://github.com/procyon-creative/jira-action-man/bl
 
 > **email**: `string`
 
-Defined in: [types.ts:21](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L21)
+Defined in: [types.ts:37](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L37)

--- a/docs/types/interfaces/PrContext.md
+++ b/docs/types/interfaces/PrContext.md
@@ -6,7 +6,7 @@
 
 # Interface: PrContext
 
-Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L25)
+Defined in: [types.ts:41](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L41)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:25](https://github.com/procyon-creative/jira-action-man/bl
 
 > **body**: `string`
 
-Defined in: [types.ts:28](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L28)
+Defined in: [types.ts:44](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L44)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:28](https://github.com/procyon-creative/jira-action-man/bl
 
 > **number**: `number`
 
-Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L26)
+Defined in: [types.ts:42](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L42)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:26](https://github.com/procyon-creative/jira-action-man/bl
 
 > **title**: `string`
 
-Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L27)
+Defined in: [types.ts:43](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L43)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:27](https://github.com/procyon-creative/jira-action-man/bl
 
 > **url**: `string`
 
-Defined in: [types.ts:29](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L29)
+Defined in: [types.ts:45](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L45)

--- a/docs/types/interfaces/SourceTexts.md
+++ b/docs/types/interfaces/SourceTexts.md
@@ -6,7 +6,7 @@
 
 # Interface: SourceTexts
 
-Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L32)
+Defined in: [types.ts:48](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L48)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [types.ts:32](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **body**: `string`
 
-Defined in: [types.ts:36](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L36)
+Defined in: [types.ts:52](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L52)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [types.ts:36](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **branch**: `string`
 
-Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L33)
+Defined in: [types.ts:49](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L49)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [types.ts:33](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **commits**: `string`[]
 
-Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L35)
+Defined in: [types.ts:51](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L51)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [types.ts:35](https://github.com/procyon-creative/jira-action-man/bl
 
 > `optional` **title**: `string`
 
-Defined in: [types.ts:34](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L34)
+Defined in: [types.ts:50](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L50)

--- a/docs/types/type-aliases/JiraCommentMode.md
+++ b/docs/types/type-aliases/JiraCommentMode.md
@@ -8,4 +8,4 @@
 
 > **JiraCommentMode** = `"update"` \| `"new"` \| `"minimal"`
 
-Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L3)
+Defined in: [types.ts:3](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L3)

--- a/docs/types/type-aliases/Source.md
+++ b/docs/types/type-aliases/Source.md
@@ -8,4 +8,4 @@
 
 > **Source** = `"branch"` \| `"title"` \| `"commits"` \| `"body"`
 
-Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/ef4120760a99c83744a455dcebfae67971159a1e/src/types.ts#L1)
+Defined in: [types.ts:1](https://github.com/procyon-creative/jira-action-man/blob/37df913da3194bdeead9a41e8c8da2c30899b860/src/types.ts#L1)

--- a/src/failure.ts
+++ b/src/failure.ts
@@ -1,0 +1,167 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { FailureContext, JiraConfig } from "./types";
+import { createIssue, searchIssue } from "./jira";
+
+/**
+ * Work out what failed, from the GitHub event context.
+ *
+ * - `workflow_run`: the natural "CI finished" signal. We only return a context
+ *   when the run actually FAILED (conclusion === "failure"); otherwise null so
+ *   the caller does nothing. PR info comes from `workflow_run.pull_requests`.
+ * - any other event (e.g. `pull_request`): we assume the workflow gated this
+ *   step on failure itself (`if: failure()`), so we build the context from the
+ *   PR payload (or the ref for pushes).
+ *
+ * Returns null when there's nothing to file a ticket for.
+ */
+export function resolveFailureContext(): FailureContext | null {
+  const { context } = github;
+  const repo =
+    (context.payload.repository?.full_name as string | undefined) ||
+    (context.payload.repository
+      ? `${context.payload.repository.owner?.login}/${context.payload.repository.name}`
+      : undefined);
+
+  if (context.eventName === "workflow_run") {
+    const wr = context.payload.workflow_run as
+      | {
+          conclusion?: string;
+          head_branch?: string;
+          html_url?: string;
+          pull_requests?: { number: number }[];
+        }
+      | undefined;
+    if (!wr) return null;
+    // Only act on genuine failures.
+    if (wr.conclusion !== "failure") return null;
+
+    const prNumber = wr.pull_requests?.[0]?.number;
+    const branch = wr.head_branch;
+    const url =
+      prNumber && repo
+        ? `https://github.com/${repo}/pull/${prNumber}`
+        : undefined;
+    return {
+      title: prNumber ? `PR #${prNumber}` : `branch ${branch ?? "?"}`,
+      repo,
+      prNumber,
+      branch,
+      url,
+      runUrl: wr.html_url,
+    };
+  }
+
+  const pr = context.payload.pull_request as
+    | {
+        number: number;
+        title?: string;
+        html_url?: string;
+        head?: { ref?: string };
+      }
+    | undefined;
+  if (pr) {
+    return {
+      title: pr.title || `PR #${pr.number}`,
+      repo,
+      prNumber: pr.number,
+      branch: pr.head?.ref,
+      url: pr.html_url,
+    };
+  }
+
+  // Fallback: a push/other event the workflow gated on failure.
+  const branch = context.ref?.replace(/^refs\/heads\//, "");
+  return { title: branch ? `branch ${branch}` : "build", repo, branch };
+}
+
+function slug(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+/**
+ * Build the summary, description and labels for a CI-failure ticket. Pure — no
+ * network. The second label is a deterministic dedup key so repeated failures of
+ * the same PR/branch reuse a single open ticket.
+ */
+export function buildFailureIssue(ctx: FailureContext): {
+  summary: string;
+  description: string;
+  labels: string[];
+  dedupeLabel: string;
+} {
+  const idLabel = ctx.prNumber
+    ? `PR #${ctx.prNumber}`
+    : ctx.branch
+      ? `branch ${ctx.branch}`
+      : "build";
+  const summary =
+    `CI failed: ${idLabel}${ctx.prNumber && ctx.branch ? ` (${ctx.branch})` : ""}`.slice(
+      0,
+      250,
+    );
+
+  const idSlug = ctx.prNumber
+    ? `pr-${ctx.prNumber}`
+    : slug(ctx.branch || "build");
+  const repoSlug = ctx.repo ? slug(ctx.repo) : "repo";
+  const dedupeLabel = `cifail-${repoSlug}-${idSlug}`.slice(0, 50);
+  const labels = ["ci-failure", dedupeLabel];
+
+  const lines = [
+    "A CI run failed. This ticket was opened automatically by jira-action-man.",
+    "",
+  ];
+  if (ctx.url) lines.push(`* PR: ${ctx.url}`);
+  if (ctx.branch) lines.push(`* Branch: {{${ctx.branch}}}`);
+  if (ctx.runUrl) lines.push(`* Failed run: ${ctx.runUrl}`);
+  if (ctx.repo) lines.push(`* Repo: ${ctx.repo}`);
+
+  return { summary, description: lines.join("\n"), labels, dedupeLabel };
+}
+
+/**
+ * Create a CI-failure ticket, unless an open one already exists for the same
+ * PR/branch (matched by the dedup label). Obeys failOnError (warn by default).
+ * Returns the issue key (existing or new), or null on a swallowed error.
+ */
+export async function createFailureIssue(
+  ctx: FailureContext,
+  config: JiraConfig,
+  projectKey: string,
+  issueType: string,
+  failOnError: boolean,
+): Promise<string | null> {
+  const { summary, description, labels, dedupeLabel } = buildFailureIssue(ctx);
+  try {
+    const jql = `project = "${projectKey}" AND statusCategory != Done AND labels = "${dedupeLabel}"`;
+    const existing = await searchIssue(config, jql);
+    if (existing) {
+      core.info(
+        `Open CI-failure ticket already exists for ${dedupeLabel}: ${existing} — not creating a duplicate`,
+      );
+      return existing;
+    }
+
+    const key = await createIssue(config, {
+      projectKey,
+      issueType,
+      summary,
+      description,
+      labels,
+    });
+    core.info(`Created CI-failure ticket ${key} (${projectKey})`);
+    return key;
+  } catch (error) {
+    const msg = `Failed to create CI-failure issue: ${error instanceof Error ? error.message : String(error)}`;
+    if (failOnError) {
+      throw new Error(msg);
+    }
+    core.warning(msg);
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./extract";
 import { collectSourceTexts, sourceTextsToArray } from "./sources";
 import { postToJira, transitionIssues } from "./jira";
+import { createFailureIssue, resolveFailureContext } from "./failure";
 
 function parseInputs(): ActionInputs {
   const projectsRaw = core.getInput("projects");
@@ -59,6 +60,12 @@ function parseInputs(): ActionInputs {
 
   const transitionTo = core.getInput("transition_to").trim() || undefined;
 
+  const createIssueOnFailure =
+    core.getInput("create_issue_on_failure") === "true";
+  const issueType = core.getInput("issue_type").trim() || "Bug";
+  const issueProject =
+    core.getInput("issue_project").trim().toUpperCase() || undefined;
+
   const githubToken = core.getInput("github_token") || undefined;
 
   const allowedHostsRaw = core.getInput("allowed_image_hosts");
@@ -79,6 +86,9 @@ function parseInputs(): ActionInputs {
     jiraCommentMode,
     jiraFailOnError,
     transitionTo,
+    createIssueOnFailure,
+    issueType,
+    issueProject,
     githubToken,
     allowedImageHosts,
   };
@@ -184,6 +194,47 @@ async function run(): Promise<void> {
             jiraConfig,
             inputs.jiraFailOnError,
           );
+        }
+      }
+    }
+
+    // Open a Jira ticket when a run has failed. Independent of issue keys —
+    // a failing dependabot PR carries no key, which is exactly the case this
+    // covers. Gated by create_issue_on_failure; the workflow decides when to
+    // run this (a workflow_run on the CI workflow, or an `if: failure()` job).
+    if (inputs.createIssueOnFailure) {
+      const jiraConfig: JiraConfig = {
+        baseUrl: core.getInput("jira_base_url"),
+        email: core.getInput("jira_email"),
+        apiToken: core.getInput("jira_api_token"),
+      };
+      const projectKey = inputs.issueProject || inputs.projects[0];
+
+      if (!jiraConfig.baseUrl || !jiraConfig.email || !jiraConfig.apiToken) {
+        const msg =
+          "create_issue_on_failure is enabled but jira_base_url, jira_email, or jira_api_token is missing";
+        if (inputs.jiraFailOnError) core.setFailed(msg);
+        else core.warning(msg);
+      } else if (!projectKey) {
+        const msg =
+          "create_issue_on_failure is enabled but no target project (set issue_project, or projects)";
+        if (inputs.jiraFailOnError) core.setFailed(msg);
+        else core.warning(msg);
+      } else {
+        const failureCtx = resolveFailureContext();
+        if (!failureCtx) {
+          core.info(
+            "create_issue_on_failure: no failed run detected for this event — skipping",
+          );
+        } else {
+          const created = await createFailureIssue(
+            failureCtx,
+            jiraConfig,
+            projectKey,
+            inputs.issueType,
+            inputs.jiraFailOnError,
+          );
+          core.setOutput("created_issue", created || "");
         }
       }
     }

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -597,3 +597,70 @@ export async function transitionIssues(
     }
   }
 }
+
+export interface CreateIssueOptions {
+  projectKey: string;
+  issueType: string;
+  summary: string;
+  description: string;
+  labels?: string[];
+}
+
+export async function createIssue(
+  config: JiraConfig,
+  opts: CreateIssueOptions,
+): Promise<string> {
+  config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+  const url = `${config.baseUrl}/rest/api/2/issue`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: authHeader(config),
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      fields: {
+        project: { key: opts.projectKey },
+        issuetype: { name: opts.issueType },
+        summary: opts.summary,
+        description: opts.description,
+        ...(opts.labels && opts.labels.length > 0
+          ? { labels: opts.labels }
+          : {}),
+      },
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `Failed to create issue in ${opts.projectKey}: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ""}`,
+    );
+  }
+  const data = (await res.json()) as { key: string };
+  return data.key;
+}
+
+// Uses the enhanced JQL search endpoint (the legacy /rest/api/2/search is being
+// sunset by Atlassian). Returns the first matching issue key, or null.
+export async function searchIssue(
+  config: JiraConfig,
+  jql: string,
+): Promise<string | null> {
+  config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+  const url = `${config.baseUrl}/rest/api/3/search/jql`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: authHeader(config),
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ jql, maxResults: 1, fields: ["key"] }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to search issues: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { issues?: { key: string }[] };
+  return data.issues?.[0]?.key ?? null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,24 @@ export interface ActionInputs {
   jiraCommentMode: JiraCommentMode;
   jiraFailOnError: boolean;
   transitionTo?: string;
+  createIssueOnFailure: boolean;
+  issueType: string;
+  issueProject?: string;
   githubToken?: string;
   allowedImageHosts?: string[];
+}
+
+export interface FailureContext {
+  /** Human label for the failing thing, e.g. "PR #6" or "branch main". */
+  title: string;
+  /** owner/repo */
+  repo?: string;
+  prNumber?: number;
+  branch?: string;
+  /** PR html_url, when a PR is associated. */
+  url?: string;
+  /** URL of the failed workflow run, when available. */
+  runUrl?: string;
 }
 
 export interface JiraConfig {

--- a/tests/failure.test.ts
+++ b/tests/failure.test.ts
@@ -1,0 +1,199 @@
+import {
+  buildFailureIssue,
+  createFailureIssue,
+  resolveFailureContext,
+} from "../src/failure";
+import { FailureContext, JiraConfig } from "../src/types";
+
+jest.mock("@actions/core", () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  setFailed: jest.fn(),
+}));
+
+const core = jest.requireMock("@actions/core") as {
+  info: jest.Mock;
+  warning: jest.Mock;
+};
+
+const mockContext = {
+  eventName: "",
+  ref: "",
+  payload: {} as Record<string, unknown>,
+};
+
+jest.mock("@actions/github", () => ({
+  get context() {
+    return mockContext;
+  },
+}));
+
+function setContext(
+  eventName: string,
+  ref: string,
+  payload: Record<string, unknown>,
+) {
+  mockContext.eventName = eventName;
+  mockContext.ref = ref;
+  mockContext.payload = payload;
+}
+
+const config: JiraConfig = {
+  baseUrl: "https://test.atlassian.net",
+  email: "user@example.com",
+  apiToken: "test-token",
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockFetch(responses: Array<{ status: number; body?: any }>) {
+  const queue = [...responses];
+  return jest.fn(async () => {
+    const next = queue.shift()!;
+    return {
+      ok: next.status >= 200 && next.status < 300,
+      status: next.status,
+      statusText: next.status >= 200 && next.status < 300 ? "OK" : "Error",
+      json: async () => next.body,
+      text: async () => "",
+    };
+  }) as unknown as jest.Mock & typeof global.fetch;
+}
+
+const prCtx: FailureContext = {
+  title: "PR #6",
+  repo: "org/repo",
+  prNumber: 6,
+  branch: "dependabot/npm_and_yarn/vite-8.0.16",
+  url: "https://github.com/org/repo/pull/6",
+  runUrl: "https://github.com/org/repo/actions/runs/1",
+};
+
+describe("buildFailureIssue", () => {
+  it("builds summary, labels and a deterministic dedup label for a PR", () => {
+    const r = buildFailureIssue(prCtx);
+    expect(r.summary).toBe(
+      "CI failed: PR #6 (dependabot/npm_and_yarn/vite-8.0.16)",
+    );
+    expect(r.labels).toEqual(["ci-failure", "cifail-org-repo-pr-6"]);
+    expect(r.dedupeLabel).toBe("cifail-org-repo-pr-6");
+    expect(r.description).toContain("https://github.com/org/repo/pull/6");
+    expect(r.description).toContain(
+      "https://github.com/org/repo/actions/runs/1",
+    );
+  });
+
+  it("falls back to the branch when there is no PR", () => {
+    const r = buildFailureIssue({
+      title: "branch main",
+      repo: "org/repo",
+      branch: "main",
+    });
+    expect(r.summary).toBe("CI failed: branch main");
+    expect(r.dedupeLabel).toBe("cifail-org-repo-main");
+  });
+
+  it("keeps the dedup label the same across repeated failures of the same PR", () => {
+    const a = buildFailureIssue(prCtx).dedupeLabel;
+    const b = buildFailureIssue({
+      ...prCtx,
+      runUrl: "different-run",
+    }).dedupeLabel;
+    expect(a).toBe(b);
+  });
+});
+
+describe("resolveFailureContext", () => {
+  beforeEach(() => setContext("", "", {}));
+
+  it("returns a context for a failed workflow_run with a PR", () => {
+    setContext("workflow_run", "", {
+      repository: { full_name: "org/repo" },
+      workflow_run: {
+        conclusion: "failure",
+        head_branch: "dependabot/x",
+        html_url: "https://github.com/org/repo/actions/runs/9",
+        pull_requests: [{ number: 6 }],
+      },
+    });
+    const ctx = resolveFailureContext();
+    expect(ctx).not.toBeNull();
+    expect(ctx!.prNumber).toBe(6);
+    expect(ctx!.url).toBe("https://github.com/org/repo/pull/6");
+    expect(ctx!.runUrl).toBe("https://github.com/org/repo/actions/runs/9");
+  });
+
+  it("returns null when the workflow_run did not fail", () => {
+    setContext("workflow_run", "", {
+      repository: { full_name: "org/repo" },
+      workflow_run: { conclusion: "success", pull_requests: [] },
+    });
+    expect(resolveFailureContext()).toBeNull();
+  });
+
+  it("uses the pull_request payload for non-workflow_run events", () => {
+    setContext("pull_request", "", {
+      repository: { full_name: "org/repo" },
+      pull_request: {
+        number: 12,
+        title: "Fix things",
+        html_url: "https://github.com/org/repo/pull/12",
+        head: { ref: "fix-things" },
+      },
+    });
+    const ctx = resolveFailureContext();
+    expect(ctx!.prNumber).toBe(12);
+    expect(ctx!.title).toBe("Fix things");
+    expect(ctx!.branch).toBe("fix-things");
+  });
+});
+
+describe("createFailureIssue", () => {
+  const origFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = origFetch;
+    jest.clearAllMocks();
+  });
+
+  it("reuses an existing open ticket and does not create a duplicate", async () => {
+    const fetchMock = mockFetch([
+      { status: 200, body: { issues: [{ key: "SONG-9" }] } },
+    ]);
+    global.fetch = fetchMock;
+    const key = await createFailureIssue(prCtx, config, "SONG", "Bug", false);
+    expect(key).toBe("SONG-9");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // search only, no create
+  });
+
+  it("creates a new ticket when none exists", async () => {
+    const fetchMock = mockFetch([
+      { status: 200, body: { issues: [] } },
+      { status: 201, body: { key: "SONG-10" } },
+    ]);
+    global.fetch = fetchMock;
+    const key = await createFailureIssue(prCtx, config, "SONG", "Bug", false);
+    expect(key).toBe("SONG-10");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // search + create
+    const [, createOpts] = fetchMock.mock.calls[1] as [
+      string,
+      { body: string },
+    ];
+    const sent = JSON.parse(createOpts.body);
+    expect(sent.fields.project.key).toBe("SONG");
+    expect(sent.fields.issuetype.name).toBe("Bug");
+    expect(sent.fields.labels).toContain("cifail-org-repo-pr-6");
+  });
+
+  it("warns and returns null on error when failOnError is false", async () => {
+    global.fetch = mockFetch([{ status: 500 }]);
+    const key = await createFailureIssue(prCtx, config, "SONG", "Bug", false);
+    expect(key).toBeNull();
+    expect(core.warning).toHaveBeenCalled();
+  });
+
+  it("throws on error when failOnError is true", async () => {
+    global.fetch = mockFetch([{ status: 500 }]);
+    await expect(
+      createFailureIssue(prCtx, config, "SONG", "Bug", true),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Adds an option to open a Jira ticket when a run fails — independent of issue keys, so it covers **failing dependabot PRs** (which carry no `PROJ-NNN`).

## New inputs
- `create_issue_on_failure` (default `false`)
- `issue_type` (default `Bug`)
- `issue_project` (defaults to first of `projects`)
- output `created_issue`

## Behavior
- Run it from a **`workflow_run`** on your CI workflow — the action reads the run's conclusion and only files on `failure`. Also works from an `if: failure()` job (uses the PR/branch context).
- **Dedup by label**: each ticket carries `ci-failure` + a deterministic `cifail-<repo>-<pr|branch>` label; an open ticket for the same target is reused instead of spawning one per run. Move it to a Done status and the next failure opens a fresh one.
- Uses `jira_base_url/email/token`; obeys `jira_fail_on_error` (warn by default). Search uses the current `/rest/api/3/search/jql` endpoint.

## Tests
New `tests/failure.test.ts` (build/dedup label, context resolution for workflow_run/pull_request, create-vs-reuse, warn/throw). Full suite: **117 passing**, lint clean, `dist` rebuilt.